### PR TITLE
Fix typelib installation directory

### DIFF
--- a/debian/libostree-dev.install
+++ b/debian/libostree-dev.install
@@ -1,4 +1,4 @@
 usr/include
 usr/lib/*/*.so
 usr/lib/*/pkgconfig
-/usr/lib/*/girepository-1.0/ usr/lib/girepository-1.0
+/usr/lib/*/girepository-1.0/ usr/lib


### PR DESCRIPTION
Without this change, it was being installed to
/usr/lib/girepository-1.0/girepository-1.0/OSTree-1.0.typelib, which is
not a valid location.

[endlessm/eos-shell#4447]