### PR TITLE
Install gir components to the correct packages

### DIFF
--- a/debian/gir1.2-ostree.install
+++ b/debian/gir1.2-ostree.install
@@ -1,1 +1,1 @@
-usr/share/gir-1.0
+usr/lib/*/girepository-1.0/ usr/lib/

--- a/debian/libostree-dev.install
+++ b/debian/libostree-dev.install
@@ -1,4 +1,4 @@
 usr/include
 usr/lib/*/*.so
 usr/lib/*/pkgconfig
-/usr/lib/*/girepository-1.0/ usr/lib
+usr/share/gir-1.0


### PR DESCRIPTION
The typelib file is needed at runtime and should be in the gir1.2
package while the gir file is only needed at buildtime and should be in
the dev package. This is how gtk and others handle the files:

  $ dpkg-query -S /usr/lib/girepository-1.0/Gtk-3.0.typelib \
    /usr/share/gir-1.0/Gtk-3.0.gir
  gir1.2-gtk-3.0: /usr/lib/girepository-1.0/Gtk-3.0.typelib
  libgtk-3-dev: /usr/share/gir-1.0/Gtk-3.0.gir

dh_girepository fails if the package containing the typelib file does
not begin with gir.

[endlessm/eos-shell#4447]