### PR TITLE
libostree: set directory mtimes to 0 on checkout

### DIFF
--- a/src/libostree/ostree-repo-checkout.c
+++ b/src/libostree/ostree-repo-checkout.c
@@ -453,6 +453,20 @@ ostree_repo_checkout_tree (OstreeRepo               *self,
         }
     }
 
+    /* Set directory mtime to 0, so that it is constant for all checkouts.
+     * Must be done last, after creating all children.
+     */
+    if (!g_file_set_attribute_uint64(destination,
+                                     "time::modified", 0,
+                                     G_FILE_QUERY_INFO_NONE,
+                                     cancellable, error))
+      goto out;
+    if (!g_file_set_attribute_uint32(destination,
+                                     "time::modified-usec", 0,
+                                     G_FILE_QUERY_INFO_NONE,
+                                     cancellable, error))
+     goto out;
+
   ret = TRUE;
  out:
   return ret;


### PR DESCRIPTION
We already set all file mtimes to 0 so that they are constant
over all checkouts, and can be made constant with a known value from
the system where the ostree was created.

However, this was not happening for directories. Zero their mtimes too.

This is important for shipping a fontconfig cache in the ostree;
the fontconfig cache files embed a directory mtime.

https://github.com/endlessm/eos-shell/issues/4601