### PR TITLE
ostree-prepare-root: log informational messages to stdout

### DIFF
--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[])
     }
 
   snprintf (destpath, sizeof(destpath), "%s/%s", root_mountpoint, ostree_target);
-  fprintf (stderr, "Examining %s\n", destpath);
+  printf ("Examining %s\n", destpath);
   if (lstat (destpath, &stbuf) < 0)
     {
       perrorv ("Couldn't find specified OSTree root '%s': ", destpath);
@@ -143,7 +143,7 @@ main(int argc, char *argv[])
       perrorv ("realpath(%s) failed: ", destpath);
       exit (1);
     }
-  fprintf (stderr, "Resolved OSTree target to: %s\n", deploy_path);
+  printf ("Resolved OSTree target to: %s\n", deploy_path);
   
   /* Work-around for a kernel bug: for some reason the kernel
    * refuses switching root if any file systems are mounted


### PR DESCRIPTION
ostree-prepare-root was logging normal, informational messages
to stderr which the systemd unit points to the console.

To achieve silent boot, log these ordinary messages to stdout only.

https://github.com/endlessm/eos-shell/issues/2109