### PR TITLE
core: Do enumerate content objects in archive-z2 repositories

### DIFF
--- a/src/libostree/ostree-repo-prune.c
+++ b/src/libostree/ostree-repo-prune.c
@@ -145,8 +145,9 @@ ostree_repo_prune (OstreeRepo        *self,
         {
           const char *checksum = value;
           
-          if (!ostree_repo_traverse_commit (self, checksum, depth, data.reachable,
-                                            cancellable, error))
+          if (!ostree_repo_traverse_commit_full (self, checksum, depth,
+                                                 data.reachable,
+                                                 cancellable, error))
             goto out;
         }
     }
@@ -169,8 +170,9 @@ ostree_repo_prune (OstreeRepo        *self,
           if (objtype != OSTREE_OBJECT_TYPE_COMMIT)
             continue;
           
-          if (!ostree_repo_traverse_commit (self, checksum, depth, data.reachable,
-                                            cancellable, error))
+          if (!ostree_repo_traverse_commit_full (self, checksum, depth,
+                                                 data.reachable,
+                                                 cancellable, error))
             goto out;
         }
     }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2357,6 +2357,10 @@ list_loose_object_dir (OstreeRepo             *self,
         objtype = OSTREE_OBJECT_TYPE_DIR_META;
       else if (g_str_has_suffix (name, ".commit"))
         objtype = OSTREE_OBJECT_TYPE_COMMIT;
+      else if (g_str_has_suffix (name, ".sig"))
+        objtype = OSTREE_OBJECT_TYPE_SIGNATURE;
+      else if (g_str_has_suffix (name, ".sizes2"))
+        objtype = OSTREE_OBJECT_TYPE_SIZES;
       else
         continue;
           

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -2346,8 +2346,10 @@ list_loose_object_dir (OstreeRepo             *self,
         continue;
 
       name = g_file_info_get_attribute_byte_string (file_info, "standard::name"); 
-      
-      if (g_str_has_suffix (name, ".file"))
+      if ((self->mode == OSTREE_REPO_MODE_ARCHIVE_Z2
+           && g_str_has_suffix (name, ".filez")) ||
+          (self->mode == OSTREE_REPO_MODE_BARE
+           && g_str_has_suffix (name, ".file")))
         objtype = OSTREE_OBJECT_TYPE_FILE;
       else if (g_str_has_suffix (name, ".dirtree"))
         objtype = OSTREE_OBJECT_TYPE_DIR_TREE;


### PR DESCRIPTION
Prune has worked fine on bare repositories for some time, but now that
I finally try to delete data on the server side, I notice we weren't
actually enumerating content objects =/

That caused them to not be pruned.

https://bugzilla.gnome.org/show_bug.cgi?id=733458
(cherry picked from commit 1834a71b1f4856612e5d0638d1f82e9831e89a39)

Conflicts:
	src/libostree/ostree-repo.c

[endlessm/eos-shell#2034]