### PR TITLE
repo: Really stop using ostree_repo_traverse_commit_full()

### DIFF
--- a/src/libostree/ostree-repo-prune.c
+++ b/src/libostree/ostree-repo-prune.c
@@ -145,9 +145,9 @@ ostree_repo_prune (OstreeRepo        *self,
         {
           const char *checksum = value;
           
-          if (!ostree_repo_traverse_commit_full (self, checksum, depth,
-                                                 data.reachable,
-                                                 cancellable, error))
+          if (!ostree_repo_traverse_commit (self, checksum, depth,
+                                            data.reachable,
+                                            cancellable, error))
             goto out;
         }
     }
@@ -170,9 +170,9 @@ ostree_repo_prune (OstreeRepo        *self,
           if (objtype != OSTREE_OBJECT_TYPE_COMMIT)
             continue;
           
-          if (!ostree_repo_traverse_commit_full (self, checksum, depth,
-                                                 data.reachable,
-                                                 cancellable, error))
+          if (!ostree_repo_traverse_commit (self, checksum, depth,
+                                            data.reachable,
+                                            cancellable, error))
             goto out;
         }
     }


### PR DESCRIPTION
This was intended in 16cdb46, but the merge on github ended up
preferring an older commit because the base of my merge request was from
before that.

[endlessm/eos-shell#4876]