### PR TITLE
Fix size calculation

### DIFF
--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3066,7 +3066,7 @@ ostree_repo_get_commit_sizes (OstreeRepo *self,
                               GCancellable *cancellable,
                               GError **error)
 {
-  gboolean ret = 0;
+  gsize ret = 0;
   gs_unref_variant GVariant *index = NULL;
   gint64 in = 0;
   gint64 out = 0;

--- a/src/ostree/ot-builtin-summary.c
+++ b/src/ostree/ot-builtin-summary.c
@@ -191,7 +191,7 @@ ostree_builtin_summary (int argc, char **argv, OstreeRepo *repo, GCancellable *c
                "  archived: %" G_GINT64_FORMAT "/%" G_GINT64_FORMAT "\n"
                "  unpacked: %" G_GINT64_FORMAT "/%" G_GINT64_FORMAT "\n",
                refspec,
-               fetch_needed - entries, entries,
+               entries - fetch_needed, entries,
                archived - new_archived, archived,
                unpacked - new_unpacked, unpacked);
     }


### PR DESCRIPTION
 - fix type of ret in ostree_repo_get_commit_sizes()
 - fix size calculation to use gint64
 - fix number of files calculation summary command

[endlessm/eos-shell#4730]