### PR TITLE
Add commit size functionality

### DIFF
--- a/Makefile-ostree.am
+++ b/Makefile-ostree.am
@@ -40,6 +40,7 @@ ostree_SOURCES = src/ostree/main.c \
 	src/ostree/ot-builtin-reset.c \
 	src/ostree/ot-builtin-rev-parse.c \
 	src/ostree/ot-builtin-summary.c \
+	src/ostree/ot-builtin-size-summary.c \
 	src/ostree/ot-builtin-show.c \
 	src/ostree/ot-builtin-static-delta.c \
 	src/ostree/ot-main.h \

--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -47,6 +47,7 @@ testfiles = test-basic \
 	test-admin-upgrade-not-backwards \
 	test-repo-checkout-subpath	\
 	test-reset-nonlinear \
+	test-size-summary \
 	test-setuid \
 	test-delta \
 	test-xattrs \

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -309,14 +309,14 @@ commit_loose_object_trusted (OstreeRepo        *self,
 typedef struct
 {
   OstreeObjectType objtype;
-  gsize unpacked;
-  gsize archived;
+  guint64 unpacked;
+  guint64 archived;
 } OstreeContentSizeCacheEntry;
 
 static OstreeContentSizeCacheEntry *
 content_size_cache_entry_new (OstreeObjectType objtype,
-                              gsize            unpacked,
-                              gsize            archived)
+                              guint64          unpacked,
+                              guint64          archived)
 {
   OstreeContentSizeCacheEntry *entry = g_slice_new0 (OstreeContentSizeCacheEntry);
 
@@ -338,8 +338,8 @@ static void
 repo_store_size_entry (OstreeRepo       *self,
                        OstreeObjectType  objtype,
                        const gchar      *checksum,
-                       gsize             unpacked,
-                       gsize             archived)
+                       guint64           unpacked,
+                       guint64           archived)
 {
   if (G_UNLIKELY (self->object_sizes == NULL))
     self->object_sizes = g_hash_table_new_full (g_str_hash, g_str_equal,
@@ -425,6 +425,134 @@ add_size_index_to_metadata (OstreeRepo        *self,
   *out_metadata = g_variant_builder_end (builder);
   g_variant_ref_sink (*out_metadata);
 
+  return ret;
+}
+
+static gboolean
+ostree_repo_commit_unpack_sizes (GVariant                    *entry,
+                                 OstreeContentSizeCacheEntry *sizes,
+                                 char                        *csum)
+{
+  gboolean ret = FALSE;
+  const guchar *buffer;
+  gsize bytes_read = 0;
+  gsize object_size = g_variant_get_size (entry);
+
+  if (object_size <= 32)
+    goto out;
+
+  buffer = g_variant_get_data (entry);
+  if (!buffer)
+    goto out;
+
+  ostree_checksum_inplace_from_bytes (buffer, csum);
+  buffer += 32;
+  object_size -= 32;
+
+  if (!_ostree_read_varuint64 (buffer, object_size, &(sizes->archived), &bytes_read))
+    goto out;
+  buffer += bytes_read;
+  object_size -= bytes_read;
+
+  if (!_ostree_read_varuint64 (buffer, object_size, &(sizes->unpacked), &bytes_read))
+    goto out;
+  buffer += bytes_read;
+  object_size -= bytes_read;
+
+  if (object_size < 1)
+    goto out;
+
+  if (*buffer < OSTREE_OBJECT_TYPE_FILE || *buffer > OSTREE_OBJECT_TYPE_LAST)
+    goto out;
+  sizes->objtype = (OstreeObjectType) *buffer;
+
+  ret = TRUE;
+out:
+  return ret;
+}
+
+gboolean
+ostree_repo_get_commit_sizes (OstreeRepo *self,
+                              const char *rev,
+                              gint64 *new_archived,
+                              gint64 *new_unpacked,
+                              gsize  *new_files,
+                              gint64 *archived,
+                              gint64 *unpacked,
+                              gsize  *files,
+                              GCancellable *cancellable,
+                              GError **error)
+{
+  gboolean ret = FALSE;
+  guint64 n_archived = 0;
+  guint64 n_unpacked = 0;
+  gsize n_files = 0;
+  guint64 t_archived = 0;
+  guint64 t_unpacked = 0;
+  gsize t_files = 0;
+  GVariantIter obj_iter;
+  gs_unref_variant GVariant *object;
+  gs_unref_variant GVariant *commit = NULL;
+  gs_unref_variant GVariant *metadata = NULL;
+  gs_unref_variant GVariant *sizes = NULL;
+
+  if (!ostree_repo_load_variant (self, OSTREE_OBJECT_TYPE_COMMIT, rev,
+                                 &commit, error))
+    {
+      g_prefix_error (error, "Failed to read commit: ");
+      goto out;
+    }
+
+  metadata = g_variant_get_child_value (commit, 0);
+
+  sizes = g_variant_lookup_value (metadata, "ostree.sizes", G_VARIANT_TYPE("aay"));
+  if (!sizes)
+    goto out; // No size data is available
+
+  g_variant_iter_init (&obj_iter, sizes);
+  while ((object = g_variant_iter_next_value (&obj_iter)))
+    {
+      OstreeContentSizeCacheEntry entry;
+      char csum[65];
+      gboolean exists;
+
+      if (!ostree_repo_commit_unpack_sizes (object, &entry, csum))
+      {
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                     "Invalid object size metadata");
+        goto out;
+      }
+      g_variant_unref (object);
+      object = NULL;
+
+      t_archived += entry.archived;
+      t_unpacked += entry.unpacked;
+
+      if (entry.objtype == OSTREE_OBJECT_TYPE_FILE)
+        t_files++;
+
+      if (!ostree_repo_has_object (self, entry.objtype,
+                                   csum, &exists, cancellable, error))
+        goto out;
+
+      // cache check completed, but file is not in cache:
+      if (!exists)
+        {
+          n_archived += entry.archived;
+          n_unpacked += entry.unpacked;
+          if (entry.objtype == OSTREE_OBJECT_TYPE_FILE)
+            n_files++;
+        }
+    }
+
+    ret = TRUE;
+    if (new_archived) *new_archived = n_archived;
+    if (new_unpacked) *new_unpacked = n_unpacked;
+    if (new_files) *new_files = n_files;
+    if (archived) *archived = t_archived;
+    if (unpacked) *unpacked = t_unpacked;
+    if (files) *files = t_files;
+out:
   return ret;
 }
 
@@ -555,8 +683,7 @@ write_object (OstreeRepo         *self,
   gboolean temp_file_is_symlink;
   gboolean object_is_symlink = FALSE;
   char loose_objpath[_OSTREE_LOOSE_PATH_MAX];
-  gssize unpacked_size = 0;
-  gboolean indexable = FALSE;
+  guint64 unpacked_size = 0;
 
   g_return_val_if_fail (expected_checksum || out_csum, FALSE);
 
@@ -660,9 +787,6 @@ write_object (OstreeRepo         *self,
           gs_unref_object GConverter *zlib_compressor = NULL;
           gs_unref_object GOutputStream *compressed_out_stream = NULL;
 
-          if (self->generate_sizes)
-            indexable = TRUE;
-
           if (!gs_file_open_in_tmpdir_at (self->tmp_dir_fd, 0644,
                                           &temp_filename, &temp_out,
                                           cancellable, error))
@@ -682,10 +806,10 @@ write_object (OstreeRepo         *self,
               /* Don't close the base; we'll do that later */
               g_filter_output_stream_set_close_base_stream ((GFilterOutputStream*)compressed_out_stream, FALSE);
               
-              unpacked_size = g_output_stream_splice (compressed_out_stream, file_input,
-                                                      0, cancellable, error);
-              if (unpacked_size < 0)
+              if (g_output_stream_splice (compressed_out_stream, file_input, 0, cancellable, error) < 0)
                 goto out;
+
+              unpacked_size = g_file_info_get_size (file_info);
             }
         }
       else
@@ -706,6 +830,7 @@ write_object (OstreeRepo         *self,
                                   cancellable, error) < 0)
         goto out;
       temp_file_is_regular = TRUE;
+      unpacked_size = file_object_length;
     }
 
   if (temp_out)
@@ -731,7 +856,7 @@ write_object (OstreeRepo         *self,
 
   g_assert (actual_checksum != NULL); /* Pacify static analysis */
           
-  if (indexable && temp_file_is_regular)
+  if (repo_mode == OSTREE_REPO_MODE_ARCHIVE_Z2 && self->generate_sizes && temp_file_is_regular)
     {
       struct stat stbuf;
 

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -308,16 +308,19 @@ commit_loose_object_trusted (OstreeRepo        *self,
 
 typedef struct
 {
+  OstreeObjectType objtype;
   gsize unpacked;
   gsize archived;
 } OstreeContentSizeCacheEntry;
 
 static OstreeContentSizeCacheEntry *
-content_size_cache_entry_new (gsize unpacked,
-                              gsize archived)
+content_size_cache_entry_new (OstreeObjectType objtype,
+                              gsize            unpacked,
+                              gsize            archived)
 {
   OstreeContentSizeCacheEntry *entry = g_slice_new0 (OstreeContentSizeCacheEntry);
 
+  entry->objtype = objtype;
   entry->unpacked = unpacked;
   entry->archived = archived;
 
@@ -333,6 +336,7 @@ content_size_cache_entry_free (gpointer entry)
 
 static void
 repo_store_size_entry (OstreeRepo       *self,
+                       OstreeObjectType  objtype,
                        const gchar      *checksum,
                        gsize             unpacked,
                        gsize             archived)
@@ -343,7 +347,7 @@ repo_store_size_entry (OstreeRepo       *self,
 
   g_hash_table_replace (self->object_sizes,
                         g_strdup (checksum),
-                        content_size_cache_entry_new (unpacked, archived));
+                        content_size_cache_entry_new (objtype, unpacked, archived));
 }
 
 static int
@@ -406,6 +410,7 @@ add_size_index_to_metadata (OstreeRepo        *self,
           e_size = g_hash_table_lookup (self->object_sizes, e_checksum);
           _ostree_write_varuint64 (buffer, e_size->archived);
           _ostree_write_varuint64 (buffer, e_size->unpacked);
+          g_string_append_c (buffer, (guchar) e_size->objtype);
 
           g_variant_builder_add (&index_builder, "@ay",
                                  ot_gvariant_new_bytearray ((guint8*)buffer->str, buffer->len));
@@ -736,7 +741,7 @@ write_object (OstreeRepo         *self,
           goto out;
         }
 
-      repo_store_size_entry (self, actual_checksum, unpacked_size, stbuf.st_size);
+      repo_store_size_entry (self, objtype, actual_checksum, unpacked_size, stbuf.st_size);
     }
 
   if (!_ostree_repo_has_loose_object (self, actual_checksum, objtype,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1035,17 +1035,21 @@ scan_commit_object (OtPullData         *pull_data,
   g_variant_get_child (commit, 6, "@ay", &tree_contents_csum);
   g_variant_get_child (commit, 7, "@ay", &tree_meta_csum);
 
-  if (!scan_one_metadata_object_c (pull_data,
-                                   ostree_checksum_bytes_peek (tree_contents_csum),
-                                   OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1,
-                                   cancellable, error))
-    goto out;
+  // If this is a metadata only pull, don't grab the top dirtree/dirmeta:
+  if (!(pull_data->flags & OSTREE_REPO_PULL_FLAGS_METADATA))
+    {
+      if (!scan_one_metadata_object_c (pull_data,
+                                       ostree_checksum_bytes_peek (tree_contents_csum),
+                                       OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1,
+                                       cancellable, error))
+        goto out;
 
-  if (!scan_one_metadata_object_c (pull_data,
-                                   ostree_checksum_bytes_peek (tree_meta_csum),
-                                   OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1,
-                                   cancellable, error))
-    goto out;
+      if (!scan_one_metadata_object_c (pull_data,
+                                       ostree_checksum_bytes_peek (tree_meta_csum),
+                                       OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1,
+                                       cancellable, error))
+        goto out;
+    }
   
   ret = TRUE;
  out:
@@ -2154,7 +2158,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     }
 
   /* iterate over commits fetched and delete any commitpartial files */
-  if (!dir_to_pull)
+  if (!(dir_to_pull || (pull_data->flags & OSTREE_REPO_PULL_FLAGS_METADATA)))
     {
       g_hash_table_iter_init (&hash_iter, requested_refs_to_fetch);
       while (g_hash_table_iter_next (&hash_iter, &key, &value))

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -664,10 +664,12 @@ gboolean ostree_repo_prune (OstreeRepo        *self,
  * OstreeRepoPullFlags:
  * @OSTREE_REPO_PULL_FLAGS_NONE: No special options for pull
  * @OSTREE_REPO_PULL_FLAGS_MIRROR: Write out refs suitable for mirrors
+ * @OSTREE_REPO_PULL_FLAGS_METADATA: Only fetch the commit object + any metadata
  */
 typedef enum {
   OSTREE_REPO_PULL_FLAGS_NONE,
-  OSTREE_REPO_PULL_FLAGS_MIRROR
+  OSTREE_REPO_PULL_FLAGS_MIRROR,
+  OSTREE_REPO_PULL_FLAGS_METADATA
 } OstreeRepoPullFlags;
 
 gboolean ostree_repo_pull (OstreeRepo             *self,

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -424,6 +424,17 @@ gboolean      ostree_repo_write_commit_detached_metadata (OstreeRepo      *self,
                                                           GCancellable    *cancellable,
                                                           GError         **error);
 
+gboolean      ostree_repo_get_commit_sizes (OstreeRepo *self,
+                                            const char   *rev,
+                                            gint64       *new_archived,
+                                            gint64       *new_unpacked,
+                                            gsize        *new_files,
+                                            gint64       *archived,
+                                            gint64       *unpacked,
+                                            gsize        *files,
+                                            GCancellable *cancellable,
+                                            GError      **error);
+
 /**
  * OstreeRepoCheckoutMode:
  * @OSTREE_REPO_CHECKOUT_MODE_NONE: No special options

--- a/src/ostree/main.c
+++ b/src/ostree/main.c
@@ -57,6 +57,7 @@ static OstreeCommand commands[] = {
   { "show", ostree_builtin_show },
   { "static-delta", ostree_builtin_static_delta },
   { "summary", ostree_builtin_summary },
+  { "size-summary", ostree_builtin_size_summary },
 #ifdef HAVE_LIBSOUP 
   { "trivial-httpd", ostree_builtin_trivial_httpd },
 #endif

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -31,12 +31,14 @@ static gboolean opt_disable_fsync;
 static gboolean opt_mirror;
 static char* opt_subpath;
 static int opt_depth = 0;
+static gboolean opt_metadata;
  
  static GOptionEntry options[] = {
    { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
    { "mirror", 0, 0, G_OPTION_ARG_NONE, &opt_mirror, "Write refs suitable for a mirror", NULL },
    { "subpath", 0, 0, G_OPTION_ARG_STRING, &opt_subpath, "Only pull the provided subpath", NULL },
    { "depth", 0, 0, G_OPTION_ARG_INT, &opt_depth, "Traverse DEPTH parents (-1=infinite) (default: 0)", "DEPTH" },
+   { "metadata", 'm', 0, G_OPTION_ARG_NONE, &opt_metadata, "Download only the metadata", NULL },
    { NULL }
  };
 
@@ -86,6 +88,9 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
 
   if (opt_mirror)
     pullflags |= OSTREE_REPO_PULL_FLAGS_MIRROR;
+
+  if (opt_metadata)
+    pullflags |= OSTREE_REPO_PULL_FLAGS_METADATA;
 
   if (strchr (argv[1], ':') == NULL)
     {

--- a/src/ostree/ot-builtin-size-summary.c
+++ b/src/ostree/ot-builtin-size-summary.c
@@ -1,0 +1,131 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Vivek Dasmohapatra <vivek@collabora.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@collabora.com>
+ */
+
+#include "config.h"
+
+#include "ot-main.h"
+#include "ot-builtins.h"
+#include "ostree.h"
+#include "otutil.h"
+
+gboolean opt_detailed;
+
+static GOptionEntry options[] = {
+  { NULL }
+};
+
+gboolean
+ostree_builtin_size_summary (int argc, char **argv, GCancellable *cancellable, GError **error)
+{
+  GOptionContext *context;
+  OstreeRepo *repo;
+  gsize entries = 0;
+  const char *remote = NULL;
+  const char *ref = NULL;
+  gs_unref_variant GVariant *index = NULL;
+  gs_free gchar *refspec = NULL;
+  gs_free gchar *revision = NULL;
+  gint64 archived = 0;
+  gint64 unpacked = 0;
+  gsize  fetch_needed = 0;
+  gint64 new_archived = 0;
+  gint64 new_unpacked = 0;
+
+  context = g_option_context_new ("[REMOTE] BRANCH - Display the summary for branch");
+  g_option_context_add_main_entries (context, options, NULL);
+
+  if (!ostree_option_context_parse (context, options, &argc, &argv, OSTREE_BUILTIN_FLAG_NONE, &repo, cancellable, error))
+    goto out;
+
+  if (!ostree_repo_open (repo, cancellable, error))
+    goto out;
+
+  switch (argc)
+    {
+    case 3:
+      remote = argv[1];
+      ref = argv[2];
+      refspec = g_strdup_printf ("%s/%s", remote, ref);
+      break;
+
+    case 2:
+      ref = argv[1];
+      refspec = g_strdup (ref);
+      break;
+
+    case 1:
+      ot_util_usage_error (context, "BRANCH must be specified", error);
+      goto out;
+
+    default:
+      ot_util_usage_error (context, "only one branch may be summarised", error);
+      goto out;
+    }
+
+  // if there's a remote, we might not have pulled the metadata yet:
+  if (!ostree_repo_resolve_rev (repo, refspec, remote != NULL, &revision, error))
+    goto out;
+
+  // nothing in the cache, but try and fetch it if it's a remote refspec:
+  if (!revision && remote)
+    {
+      OstreeRepoPullFlags flags = OSTREE_REPO_PULL_FLAGS_METADATA;
+      gchar *pullrefs[] = { (gchar *) ref, NULL };
+
+      if (!ostree_repo_pull (repo, remote, pullrefs, flags, NULL, cancellable, error))
+        goto out;
+
+      if (!ostree_repo_resolve_rev (repo, refspec, FALSE, &revision, error))
+        goto out;
+    }
+
+  if (!revision)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   "Refspec '%s' not found", refspec);
+      goto out;
+    }
+
+  if (ostree_repo_get_commit_sizes (repo, revision,
+                                    &new_archived,
+                                    &new_unpacked,
+                                    &fetch_needed,
+                                    &archived, &unpacked,
+                                    &entries,
+                                    cancellable, error))
+    {
+      g_print ("Summary for refspec %s:\n"
+               "  files: %" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT " entries\n"
+               "  archived: %" G_GINT64_FORMAT "/%" G_GINT64_FORMAT "\n"
+               "  unpacked: %" G_GINT64_FORMAT "/%" G_GINT64_FORMAT "\n",
+               refspec,
+               entries - fetch_needed, entries,
+               archived - new_archived, archived,
+               unpacked - new_unpacked, unpacked);
+    }
+
+ out:
+  if (context)
+    g_option_context_free (context);
+
+  return entries != 0;
+}

--- a/src/ostree/ot-builtins.h
+++ b/src/ostree/ot-builtins.h
@@ -48,6 +48,7 @@ BUILTINPROTO(fsck);
 BUILTINPROTO(show);
 BUILTINPROTO(static_delta);
 BUILTINPROTO(summary);
+BUILTINPROTO(size_summary);
 BUILTINPROTO(rev_parse);
 BUILTINPROTO(remote);
 BUILTINPROTO(write_refs);

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -156,7 +156,7 @@ setup_fake_remote_repo1() {
     echo hi > baz/deeper/ohyeah
     mkdir baz/another/
     echo x > baz/another/y
-    ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo commit --add-metadata-string version=3.2 -b main -s "The rest"
+    ${CMD_PREFIX} ostree --repo=${test_tmpdir}/ostree-srv/gnomerepo commit --generate-sizes --add-metadata-string version=3.2 -b main -s "The rest"
     cd ..
     rm -rf gnomerepo-files
     

--- a/tests/test-size-summary.sh
+++ b/tests/test-size-summary.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright (C) 2015 Endless Mobile, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+#
+# Author: John Hiesey <john@endlessm.com>
+
+set -e
+
+. $(dirname $0)/libtest.sh
+
+setup_fake_remote_repo1 "archive-z2"
+
+echo '1..3'
+
+cd ${test_tmpdir}
+rm repo -rf
+mkdir repo
+${CMD_PREFIX} ostree --repo=repo init
+${CMD_PREFIX} ostree --repo=repo remote add --set=gpg-verify=false origin $(cat httpd-address)/ostree/gnomerepo
+${CMD_PREFIX} ostree --repo=repo size-summary origin main | tee sizes.txt
+echo "ok size summary run"
+assert_file_has_content sizes.txt "files: 0/5 entries"
+assert_file_has_content sizes.txt "archived: 0"
+assert_file_has_content sizes.txt "unpacked: 0"
+echo "ok size summary correct before pull"
+
+${CMD_PREFIX} ostree --repo=repo pull origin main
+${CMD_PREFIX} ostree --repo=repo size-summary origin main | tee sizes.txt
+assert_file_has_content sizes.txt "files: 5/5 entries"
+assert_file_has_content sizes.txt "archived: \([0-9]*\)/\1"
+assert_file_has_content sizes.txt "unpacked: \([0-9]*\)/\1"
+echo "ok size summary correct after pull"

--- a/tests/test-sizes.js
+++ b/tests/test-sizes.js
@@ -56,25 +56,31 @@ let [,commitVariant] = repo.load_variant(OSTree.ObjectType.COMMIT, commit);
 let metadata = commitVariant.get_child_value(0);
 let sizes = metadata.lookup_value('ostree.sizes', GLib.VariantType.new('aay'));
 let nSizes = sizes.n_children();
-assertEquals(nSizes, 2);
+assertEquals(nSizes, 4);
 let expectedUncompressedSizes = [12, 18];
-let foundExpectedUncompressedSizes = 0;
+let foundFiles = 0;
 for (let i = 0; i < nSizes; i++) {
     let sizeEntry = sizes.get_child_value(i).deep_unpack();
-    assertEquals(sizeEntry.length, 34);
+    assertEquals(sizeEntry.length, 35);
     let compressedSize = sizeEntry[32];
     let uncompressedSize = sizeEntry[33];
+    let objType = sizeEntry[34];
     print("compressed = " + compressedSize);
     print("uncompressed = " + uncompressedSize);
-    for (let j = 0; j < expectedUncompressedSizes.length; j++) {
-	let expected = expectedUncompressedSizes[j];
-	if (expected == uncompressedSize) {
-	    print("Matched expected uncompressed size " + expected);
-	    expectedUncompressedSizes.splice(j, 1);
-	    break;
-	}
+    print("object type = " + objType);
+    if (objType === OSTree.ObjectType.FILE) {
+        foundFiles++;
+        for (let j = 0; j < expectedUncompressedSizes.length; j++) {
+            let expected = expectedUncompressedSizes[j];
+            if (expected == uncompressedSize) {
+                print("Matched expected uncompressed size " + expected);
+                expectedUncompressedSizes.splice(j, 1);
+                break;
+            }
+        }
     }
 }
+assertEquals(foundFiles, 2);
 if (expectedUncompressedSizes.length > 0) {
     throw new Error("Failed to match expectedUncompressedSizes: " + JSON.stringify(expectedUncompressedSizes));
 }


### PR DESCRIPTION
This PR adds support for reading the upstream commit size format. This is the first step in implementing https://github.com/endlessm/eos-shell/issues/1965