### PR TITLE
tests: Link test-gpg-verify-result with gpgme

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -148,8 +148,8 @@ tests_test_ot_tool_util_LDADD = $(TESTS_LDADD)
 tests_test_gpg_verify_result_SOURCES = \
 	src/libostree/ostree-gpg-verify-result-private.h \
 	tests/test-gpg-verify-result.c
-tests_test_gpg_verify_result_CFLAGS = $(TESTS_CFLAGS)
-tests_test_gpg_verify_result_LDADD = $(TESTS_LDADD)
+tests_test_gpg_verify_result_CFLAGS = $(TESTS_CFLAGS) $(GPGME_CFLAGS)
+tests_test_gpg_verify_result_LDADD = $(TESTS_LDADD) $(GPGME_LIBS)
 
 EXTRA_DIST += \
 	tests/gpg-verify-data/README.md \


### PR DESCRIPTION
This test uses gpgme directly to verify the signatures, so it needs to
find the gpgme headers and link with gpgme to ensure the linker can
resolve the symbols.