### PR TITLE
Port the ostree daemon over

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ _build
 /ostree
 /ostree-prepare-root
 /ostree-remount
+/ostree-daemon
 /OSTree-1.0.gir
 
 /src/libostree/ostree-1.pc
@@ -74,3 +75,7 @@ test*.test
 *.tar.xz
 *.src.rpm
 packaging/*.spec
+
+/src/daemon/ostree-daemon-generated.*
+/*.conf
+/*.service

--- a/Makefile-daemon.am
+++ b/Makefile-daemon.am
@@ -1,0 +1,100 @@
+# Makefile for C source code
+#
+# Copyright © 2013 Vivek Dasmohapatra <vivek@collabora.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+bin_PROGRAMS += ostree-daemon
+bin_SCRIPTS += src/daemon/ostree-daemon-ctl
+
+EXTRA_DIST += src/daemon/ostree-daemon-ifname.xslt \
+	src/daemon/ostree-daemon-policy.xslt \
+	src/daemon/ostree-daemon-service.xslt \
+	src/daemon/ostree-daemon.xml \
+	src/daemon/ostree-daemon-ctl \
+	$(NULL)
+
+ostree_daemon_dbus_if := \
+	$(shell $(XSLTPROC) $(srcdir)/src/daemon/ostree-daemon-ifname.xslt \
+		$(srcdir)/src/daemon/ostree-daemon.xml)
+
+dbusconfdir = ${sysconfdir}/dbus-1/system.d
+dbussystemservicedir = $(datadir)/dbus-1/system-services
+
+dbusconf_DATA = $(ostree_daemon_dbus_if).conf
+dbussystemservice_DATA = $(ostree_daemon_dbus_if).service
+CLEANFILES += $(dbusconf_DATA) $(dbussystemservice_DATA)
+
+ostree_daemon_gen_objects := src/daemon/ostree-daemon-generated.o
+ostree_daemon_gen_sources := \
+	src/daemon/ostree-daemon-generated.h \
+	src/daemon/ostree-daemon-generated.c \
+	$(NULL)
+
+ostree_daemon_SOURCES := \
+	$(ostree_daemon_gen_sources) \
+	src/daemon/ostree-daemon-apply.c \
+	src/daemon/ostree-daemon-apply.h \
+	src/daemon/ostree-daemon-fetch.c \
+	src/daemon/ostree-daemon-fetch.h \
+	src/daemon/ostree-daemon-poll.c \
+	src/daemon/ostree-daemon-poll.h \
+	src/daemon/ostree-daemon-util.c \
+	src/daemon/ostree-daemon-util.h \
+	src/daemon/ostree-daemon.c \
+	src/daemon/ostree-daemon.h \
+	src/daemon/ostree-daemon.xml \
+	$(NULL)
+
+ostree_daemon_bin_shared_ldadd = \
+	libostree-1.la\
+	$(OT_DEP_GIO_UNIX_LIBS) \
+	$(OT_DEP_SOUP_LIBS)
+ostree_daemon_bin_shared_cflags = \
+	$(AM_CFLAGS) \
+	$(OT_DEP_GIO_UNIX_CFLAGS) \
+	$(OT_DEP_SOUP_CFLAGS) \
+	-I$(srcdir)/src/libotutil \
+	-I$(srcdir)/src/libostree \
+	-I$(srcdir)/src/ostree \
+	-I$(srcdir)/src/daemon \
+	-I$(srcdir)/libglnx \
+	-DLOCALEDIR=\"$(datadir)/locale\"
+
+ostree_daemon_CFLAGS = \
+	$(ostree_daemon_bin_shared_cflags) \
+	$(OT_INTERNAL_GIO_UNIX_CFLAGS) \
+	$(OT_INTERNAL_SOUP_CFLAGS)
+ostree_daemon_LDADD  = \
+	$(ostree_daemon_bin_shared_ldadd) \
+	$(OT_INTERNAL_GIO_UNIX_LIBS) \
+	$(OT_INTERNAL_SOUP_LIBS)
+
+$(ostree_daemon_OBJECTS): $(ostree_daemon_gen_sources)
+
+$(ostree_daemon_gen_sources): src/daemon/ostree-daemon.xml
+	@cd $(<D) && gdbus-codegen              \
+	   --interface-prefix $(basename $(ostree_daemon_dbus_if)). \
+	   --generate-c-code $(basename $(@F))  \
+	   --c-namespace OTD                    \
+	   --c-generate-object-manager          \
+	   $(<F)
+
+$(ostree_daemon_dbus_if).conf: src/daemon/ostree-daemon-policy.xslt src/daemon/ostree-daemon.xml
+	$(XSLTPROC) $+ > $@
+
+$(ostree_daemon_dbus_if).service: src/daemon/ostree-daemon-service.xslt src/daemon/ostree-daemon.xml
+	$(XSLTPROC) $+ > $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,10 @@ include Makefile-switchroot.am
 include Makefile-tests.am
 include Makefile-boot.am
 
+if USE_LIBSOUP
+include Makefile-daemon.am
+endif
+
 release-tag:
 	git tag -m "Release $(VERSION)" v$(VERSION)
 

--- a/src/daemon/ostree-daemon-apply.c
+++ b/src/daemon/ostree-daemon-apply.c
@@ -1,0 +1,159 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#include "ostree-daemon-apply.h"
+#include "ostree-deployment.h"
+#include <ostree.h>
+
+static void
+apply_finished (GObject *object,
+                GAsyncResult *res,
+                gpointer user_data)
+{
+  OTDOSTree *ostree = OTD_OSTREE (object);
+  GTask *task;
+  GError *error = NULL;
+
+  gs_unref_object OstreeRepo *repo = OSTREE_REPO (user_data);
+  gboolean bootver_changed = FALSE;
+
+  if (!g_task_is_valid (res, object))
+    goto invalid_task;
+
+  task = G_TASK (res);
+  bootver_changed = g_task_propagate_boolean (task, &error);
+
+  if (!bootver_changed)
+    message ("System redeployed same boot version");
+
+  if (error)
+    {
+      ostree_daemon_set_error (ostree, error);
+      g_clear_error (&error);
+    }
+  else
+    {
+      otd_ostree_set_error_code (ostree, 0);
+      otd_ostree_set_error_message (ostree, "");
+      ostree_daemon_set_state (ostree, OTD_STATE_UPDATE_APPLIED);
+    }
+
+  return;
+
+ invalid_task:
+  // Either the threading or the memory management is shafted. Or both.
+  // We're boned. Log an error and activate the self destruct mechanism:
+  g_error ("Invalid async task object when returning from Poll() thread!");
+  g_assert_not_reached ();
+}
+
+static void
+apply (GTask *task,
+       gpointer object,
+       gpointer task_data,
+       GCancellable *cancel)
+{
+  OTDOSTree *ostree = OTD_OSTREE (object);
+  GError *error = NULL;
+  GMainContext *task_context = g_main_context_new ();
+  const gchar *update_id = otd_ostree_get_update_id (ostree);
+  gint bootversion = 0;
+  gint newbootver = 0;
+  gs_unref_object OstreeDeployment *merge_deployment = NULL;
+  gs_unref_object OstreeDeployment *new_deployment = NULL;
+  GKeyFile *origin = NULL;
+  OstreeSysroot *sysroot = NULL;
+
+  g_main_context_push_thread_default (task_context);
+
+  sysroot = ostree_sysroot_new_default ();
+  if (!ostree_sysroot_load (sysroot, cancel, &error))
+    goto error;
+
+  bootversion = ostree_sysroot_get_bootversion (sysroot);
+  merge_deployment = ostree_sysroot_get_merge_deployment (sysroot, NULL);
+  origin = ostree_deployment_get_origin (merge_deployment);
+
+  if (!ostree_sysroot_deploy_tree (sysroot,
+                                   NULL,
+                                   update_id,
+                                   origin,
+                                   merge_deployment,
+                                   NULL,
+                                   &new_deployment,
+                                   cancel,
+                                   &error))
+    goto error;
+
+  if (!ostree_sysroot_simple_write_deployment (sysroot,
+                                               NULL,
+                                               new_deployment,
+                                               merge_deployment,
+                                               0,
+                                               cancel,
+                                               &error))
+    goto error;
+
+  newbootver = ostree_deployment_get_deployserial (new_deployment);
+
+  g_task_return_boolean (task, bootversion != newbootver);
+  goto cleanup;
+
+ error:
+  g_task_return_error (task, error);
+
+ cleanup:
+  g_main_context_pop_thread_default (task_context);
+  g_main_context_unref (task_context);
+  return;
+}
+
+gboolean
+handle_apply (OTDOSTree             *ostree,
+              GDBusMethodInvocation *call,
+              gpointer               user_data)
+{
+  OstreeRepo *repo = OSTREE_REPO (user_data);
+  GTask *task = NULL;
+  OTDState state = otd_ostree_get_state (ostree);
+
+  switch (state)
+    {
+    case OTD_STATE_UPDATE_READY:
+      break;
+    default:
+      g_dbus_method_invocation_return_error (call,
+        OTD_ERROR, OTD_ERROR_WRONG_STATE,
+        "Can't call Apply() while in state %s", otd_state_to_string (state));
+      goto bail;
+    }
+
+  ostree_daemon_set_state (ostree, OTD_STATE_APPLYING_UPDATE);
+  task = g_task_new (ostree, NULL, apply_finished, g_object_ref (repo));
+  g_task_set_task_data (task, g_object_ref (repo), g_object_unref);
+  g_task_run_in_thread (task, apply);
+
+  otd_ostree_complete_apply (ostree, call);
+
+bail:
+  return TRUE;
+}

--- a/src/daemon/ostree-daemon-apply.h
+++ b/src/daemon/ostree-daemon-apply.h
@@ -1,0 +1,35 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#pragma once
+
+#include "ostree-daemon-generated.h"
+#include "ostree-daemon-util.h"
+#include <ostree.h>
+
+G_BEGIN_DECLS
+
+gboolean handle_apply (OTDOSTree             *ostree,
+                       GDBusMethodInvocation *call,
+                       gpointer               user_data);
+
+G_END_DECLS

--- a/src/daemon/ostree-daemon-ctl
+++ b/src/daemon/ostree-daemon-ctl
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright © 2013 Sjoerd Simons <sjoerd.simons@collabora.co.uk>
+#
+# Quick test command line for ostree-daemon
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+import sys
+from gi.repository import GObject, Gio, GLib
+
+OTDStates = [
+  "None",
+  "Ready",
+  "Error",
+  "Polling",
+  "UpdateAvailable",
+  "Fetching",
+  "UpdateReady",
+  "ApplyingUpdate",
+  "UpdateApplied"
+]
+
+def signal_emitted (proxy, signal, parameters):
+  if (signal != "StateChanged"):
+      return
+  print "======= State changed to: " + OTDStates[parameters[0]] +  " ======="
+
+def dump_daemon_properties (proxy):
+
+  print "======= Properties ======="
+  s = proxy.get_cached_property ("State").get_uint32()
+  print "State: " + OTDStates[s]
+
+  for x in proxy.get_cached_property_names():
+    if x != "State":
+        print " " + x + ": " + str(proxy.get_cached_property(x))
+  print ""
+
+def main (argv):
+  loop = GObject.MainLoop()
+
+  b = Gio.bus_get_sync (Gio.BusType.SYSTEM, None)
+  dproxy = Gio.DBusProxy.new_sync (b, 0, None,
+    'org.gnome.OSTree',
+    '/org/gnome/OSTree',
+    'org.gnome.OSTree', None)
+
+  if len(argv) > 1:
+    methods = { "poll": "Poll",
+                "fetch": "Fetch",
+                "apply": "Apply" }
+    if argv[1] in methods.keys():
+      dproxy.call_sync ("org.gnome.OSTree." + methods[argv[1]],
+        None,
+        0, -1, None)
+      sys.exit(0)
+    else:
+      print "Unknown action: " + argv[1]
+
+  dproxy.connect ('g-properties-changed',
+    lambda proxy, changed, invalidated, user_data:
+      dump_daemon_properties (proxy), None)
+
+  dproxy.connect ('g-signal',
+    lambda proxy, sender, signal, parameters, user_data:
+      signal_emitted (proxy, signal, parameters), None)
+
+  dump_daemon_properties (dproxy)
+
+  loop.run()
+
+if __name__ == '__main__':
+  main(sys.argv)

--- a/src/daemon/ostree-daemon-fetch.c
+++ b/src/daemon/ostree-daemon-fetch.c
@@ -1,0 +1,188 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#include "ostree-daemon-fetch.h"
+
+static void
+content_fetch_finished (GObject *object,
+                        GAsyncResult *res,
+                        gpointer user_data)
+{
+  OTDOSTree *ostree = OTD_OSTREE (object);
+  GTask *task;
+  GError *error = NULL;
+
+  gs_unref_object OstreeRepo *repo = OSTREE_REPO (user_data);
+  gboolean fetched = FALSE;
+
+  if (!g_task_is_valid (res, object))
+    goto invalid_task;
+
+  task = G_TASK (res);
+  fetched = g_task_propagate_boolean (task, &error);
+
+  if (error)
+    {
+      ostree_daemon_set_error (ostree, error);
+    }
+  else if (!fetched) // bizarre, should not happen
+    {
+      otd_ostree_set_error_code (ostree, G_IO_ERROR_NOT_FOUND);
+      otd_ostree_set_error_message (ostree, "Update not found on server");
+      ostree_daemon_set_state (ostree, OTD_STATE_ERROR);
+    }
+  else
+    {
+      otd_ostree_set_error_code (ostree, 0);
+      otd_ostree_set_error_message (ostree, "");
+      ostree_daemon_set_state (ostree, OTD_STATE_UPDATE_READY);
+    }
+
+  return;
+
+ invalid_task:
+  // Either the threading or the memory management is shafted. Or both.
+  // We're boned. Log an error and activate the self destruct mechanism:
+  g_error ("Invalid async task object when returning from Poll() thread!");
+  g_assert_not_reached ();
+}
+
+typedef struct {
+  OTDOSTree *otd;
+  OstreeRepo *repo;
+  guint fetched;
+  guint requested;
+  guint64 bytes;
+} ProgressData;
+
+static void
+update_progress (OstreeAsyncProgress *progress,
+                 gpointer object)
+{
+  OTDOSTree *ostree = OTD_OSTREE (object);
+  guint64 bytes = ostree_async_progress_get_uint64 (progress,
+                                                    "bytes-transferred");
+
+  /* Idle could have been scheduled after the fetch completed, make sure we
+   * don't override the downloaded bytes */
+  if ( otd_ostree_get_state (ostree) == OTD_STATE_FETCHING)
+    otd_ostree_set_downloaded_bytes (ostree, bytes);
+}
+
+static void
+content_fetch (GTask *task,
+               gpointer object,
+               gpointer task_data,
+               GCancellable *cancel)
+{
+  OTDOSTree *ostree = OTD_OSTREE (object);
+  OstreeRepo *repo = OSTREE_REPO (task_data);
+  OstreeRepoPullFlags flags = OSTREE_REPO_PULL_FLAGS_NONE;
+  OstreeAsyncProgress *progress = NULL;
+  GError *error = NULL;
+  gs_free gchar *src = NULL;
+  gs_free gchar *ref = NULL;
+  gs_free gchar *sum = NULL;
+  gchar *pullrefs[] = { NULL, NULL };
+  GMainContext *task_context = g_main_context_new ();
+
+  g_main_context_push_thread_default (task_context);
+
+  if (!ostree_daemon_resolve_upgrade (ostree, repo, &src, &ref, &sum, &error))
+    goto error;
+
+  message ("Fetch: %s:%s resolved to: %s", src, ref, sum);
+  message ("User asked us for commit: %s", otd_ostree_get_update_id (ostree));
+
+  // rather than re-resolving the update, we get the las ID that the
+  // user Poll()ed. We do this because that is the last update for which
+  // we had size data: If there's been a new update since, then the
+  // system hasn;t seen the download/unpack sizes for that so it cannot
+  // be considered to have been approved.
+  pullrefs[0] = (gchar *) otd_ostree_get_update_id (ostree);
+
+  progress = ostree_async_progress_new_and_connect (update_progress, ostree);
+
+  // FIXME: upstream ostree_repo_pull had an unbalanced
+  // g_main_context_get_thread_default/g_main_context_unref
+  // instead of
+  // g_main_context_ref_thread_default/g_main_context_unref
+  // patch has been accepted upstream, but double check when merging
+  if (!ostree_repo_pull (repo, src, pullrefs, flags, progress, cancel, &error))
+    goto error;
+
+  message ("Fetch: pull() completed");
+
+  if (!ostree_repo_read_commit (repo, pullrefs[0], NULL, NULL, cancel, &error))
+    {
+      if (!error)
+        g_set_error (&error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                     "Failed to fetch update %s from %s", ref, src);
+      goto error;
+    }
+
+  message ("Fetch: commit %s cached", pullrefs[0]);
+  g_task_return_boolean (task, TRUE);
+  goto cleanup;
+
+ error:
+  message ("Fetch returning ERROR");
+  g_task_return_error (task, error);
+
+ cleanup:
+  if (progress)
+    ostree_async_progress_finish(progress);
+  g_main_context_pop_thread_default (task_context);
+  g_main_context_unref (task_context);
+  return;
+}
+
+gboolean
+handle_fetch (OTDOSTree             *ostree,
+              GDBusMethodInvocation *call,
+              gpointer               user_data)
+{
+  OstreeRepo *repo = OSTREE_REPO (user_data);
+  GTask *task = NULL;
+  OTDState state = otd_ostree_get_state (ostree);
+
+  switch (state)
+    {
+      case OTD_STATE_UPDATE_AVAILABLE:
+        break;
+      default:
+        g_dbus_method_invocation_return_error (call,
+          OTD_ERROR, OTD_ERROR_WRONG_STATE,
+          "Can't call Fetch() while in state %s", otd_state_to_string (state));
+      goto bail;
+    }
+
+  ostree_daemon_set_state (ostree, OTD_STATE_FETCHING);
+  task = g_task_new (ostree, NULL, content_fetch_finished, g_object_ref (repo));
+  g_task_set_task_data (task, g_object_ref (repo), g_object_unref);
+  g_task_run_in_thread (task, content_fetch);
+
+  otd_ostree_complete_fetch (ostree, call);
+
+bail:
+  return TRUE;
+}

--- a/src/daemon/ostree-daemon-fetch.h
+++ b/src/daemon/ostree-daemon-fetch.h
@@ -1,0 +1,35 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#pragma once
+
+#include "ostree-daemon-generated.h"
+#include "ostree-daemon-util.h"
+#include <ostree.h>
+
+G_BEGIN_DECLS
+
+gboolean handle_fetch (OTDOSTree             *ostree,
+                       GDBusMethodInvocation *call,
+                       gpointer               user_data);
+
+G_END_DECLS

--- a/src/daemon/ostree-daemon-ifname.xslt
+++ b/src/daemon/ostree-daemon-ifname.xslt
@@ -1,0 +1,13 @@
+<xsl:stylesheet version = '1.0'
+     xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
+  <xsl:output omit-xml-declaration="yes"/>
+
+  <xsl:template match="//interface[@name][1]">
+    <xsl:value-of select="@name"/>
+  </xsl:template>
+
+  <!-- this strips out all the non-tag text so that
+       we don't emit lots of unwanted inter-tag whitespace  -->
+  <xsl:template match="text()"/>
+
+</xsl:stylesheet> 

--- a/src/daemon/ostree-daemon-policy.xslt
+++ b/src/daemon/ostree-daemon-policy.xslt
@@ -1,0 +1,75 @@
+<xsl:stylesheet version = '1.0'
+     xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
+  <xsl:output indent="yes"
+              doctype-system="http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd"
+              doctype-public="-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"/>
+  <xsl:template match="/node">
+    <xsl:variable name="dest">
+      <xsl:value-of select="//interface[@name]/@name"/>
+    </xsl:variable>
+    <busconfig>
+      <policy user="root">
+        <xsl:comment> Allow root to own/send-to each interface </xsl:comment>
+        <xsl:for-each select="//interface[@name]">
+          <xsl:variable name="if"><xsl:value-of select="@name"/></xsl:variable>
+          <allow>
+            <xsl:attribute name="own">
+              <xsl:value-of select="$if"/>
+            </xsl:attribute>
+          </allow>
+          <allow>
+            <xsl:attribute name="send_interface">
+              <xsl:value-of select="$if"/>
+            </xsl:attribute>
+          </allow>
+        </xsl:for-each>
+        <xsl:comment> And the standard introspection interfaces </xsl:comment>
+        <allow send_interface="org.freedesktop.DBus.Introspectable">
+          <xsl:attribute name="send_destination">
+            <xsl:value-of select="$dest"/>
+          </xsl:attribute>
+        </allow>
+        <allow send_interface="org.freedesktop.DBus.Properties">
+          <xsl:attribute name="send_destination">
+            <xsl:value-of select="$dest"/>
+          </xsl:attribute>
+        </allow>
+      </policy>
+      <policy at_console="true">
+        <xsl:comment> Console user can send to the main interface </xsl:comment>
+        <allow>
+          <xsl:attribute name="send_interface">
+            <xsl:value-of select="$dest"/>
+          </xsl:attribute>
+        </allow>
+        <xsl:for-each select="//interface[@name]">
+          <xsl:if test="not (position() = 1)">
+            <xsl:variable name="if">
+              <xsl:value-of select="@name"/>
+            </xsl:variable>
+            <xsl:comment> And also <xsl:value-of select="$if"/><xsl:text> </xsl:text></xsl:comment>
+            <allow>
+              <xsl:attribute name="send_interface">
+                <xsl:value-of select="$if"/>
+              </xsl:attribute>
+              <xsl:attribute name="send_destination">
+                <xsl:value-of select="$dest"/>
+              </xsl:attribute>
+            </allow>
+          </xsl:if>
+        </xsl:for-each>
+        <xsl:comment> And the standard introspection interfaces </xsl:comment>
+        <allow send_interface="org.freedesktop.DBus.Introspectable">
+          <xsl:attribute name="send_destination">
+            <xsl:value-of select="$dest"/>
+          </xsl:attribute>
+        </allow>
+        <allow send_interface="org.freedesktop.DBus.Properties">
+          <xsl:attribute name="send_destination">
+            <xsl:value-of select="$dest"/>
+          </xsl:attribute>
+        </allow>
+      </policy>
+    </busconfig>
+  </xsl:template>
+</xsl:stylesheet> 

--- a/src/daemon/ostree-daemon-poll.c
+++ b/src/daemon/ostree-daemon-poll.c
@@ -1,0 +1,239 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#include "ostree-daemon-poll.h"
+
+static void
+metadata_fetch_finished (GObject *object,
+                         GAsyncResult *res,
+                         gpointer user_data)
+{
+  OTDOSTree *ostree = OTD_OSTREE (object);
+  GTask     *task;
+  GError    *error = NULL;
+
+  gs_free gchar *csum;
+  gs_unref_object OstreeRepo *repo = OSTREE_REPO (user_data);
+
+  if (!g_task_is_valid (res, object))
+    goto invalid_task;
+
+  // get the sha256 of the fetched update:
+  task = G_TASK (res);
+  csum = g_task_propagate_pointer (task, &error);
+
+  if (csum)
+    {
+      gint64 archived = -1;
+      gint64 unpacked = -1;
+      gint64 new_archived = 0;
+      gint64 new_unpacked = 0;
+      gs_unref_variant GVariant *commit = NULL;
+      gs_free gchar *cur = NULL;
+      const gchar *label;
+      const gchar *message;
+
+      // get the sha256 sum uf the currently booted image:
+      if (!ostree_daemon_resolve_upgrade (ostree, repo, NULL, NULL, &cur, &error))
+        goto out;
+
+      // Everything is happy thusfar
+      otd_ostree_set_error_code (ostree, 0);
+      otd_ostree_set_error_message (ostree, "");
+      // if we have a checksum for the remote upgrade candidate
+      // and it's ≠ what we're currently booted into, advertise it as such:
+      if (g_strcmp0 (cur, csum) != 0) {
+        ostree_daemon_set_state (ostree, OTD_STATE_UPDATE_AVAILABLE);
+        }
+      else
+        {
+          ostree_daemon_set_state (ostree, OTD_STATE_READY);
+          goto out;
+        }
+
+      otd_ostree_set_update_id (ostree, csum);
+
+      if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT,
+                                     csum, &commit, &error))
+        goto out;
+
+      g_variant_get_child (commit, 3, "&s", &label);
+      g_variant_get_child (commit, 4, "&s", &message);
+      otd_ostree_set_update_label (ostree, label ? label : "");
+      otd_ostree_set_update_message (ostree, message ? message : "");
+
+      if (ostree_repo_get_commit_sizes (repo, csum,
+                                        &new_archived, &new_unpacked,
+                                        NULL,
+                                        &archived, &unpacked,
+                                        NULL,
+                                        g_task_get_cancellable (task),
+                                        &error))
+        {
+          otd_ostree_set_full_download_size (ostree, archived);
+          otd_ostree_set_full_unpacked_size (ostree, unpacked);
+          otd_ostree_set_download_size (ostree, new_archived);
+          otd_ostree_set_unpacked_size (ostree, new_unpacked);
+          otd_ostree_set_downloaded_bytes (ostree, 0);
+        }
+      else // no size data available (may or may not be an error):
+        {
+          otd_ostree_set_full_download_size (ostree, -1);
+          otd_ostree_set_full_unpacked_size (ostree, -1);
+          otd_ostree_set_download_size (ostree, -1);
+          otd_ostree_set_unpacked_size (ostree, -1);
+          otd_ostree_set_downloaded_bytes (ostree, -1);
+
+          // shouldn't actually stop us offering an update, as long
+          // as the branch itself is resolvable in the next step,
+          // but log it anyway:
+          if (error)
+            {
+              message ("No size summary data: %s", error->message);
+              g_clear_error (&error);
+            }
+        }
+
+      // get the sha256 sum uf the currently booted image:
+      if (!ostree_daemon_resolve_upgrade (ostree, repo, NULL, NULL, &cur, &error))
+        goto out;
+    }
+  else if (!error) // this should never happen, but check for it anyway:
+    {
+      g_set_error (&error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   "Update not found on server");
+      goto out;
+    }
+
+ out:
+  if (error)
+    {
+      ostree_daemon_set_error (ostree, error);
+      g_clear_error (&error);
+    }
+  return;
+
+ invalid_task:
+  // Either the threading or the memory management is shafted. Or both.
+  // We're boned. Log an error and activate the self destruct mechanism:
+  g_error ("Invalid async task object when returning from Poll() thread!");
+  g_assert_not_reached ();
+}
+
+static void
+metadata_fetch (GTask *task,
+                gpointer object,
+                gpointer task_data,
+                GCancellable *cancel)
+{
+  OTDOSTree *ostree = OTD_OSTREE (object);
+  OstreeRepo *repo = OSTREE_REPO (task_data);
+  OstreeRepoPullFlags flags = (OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY);
+  GError *error = NULL;
+  gs_free gchar *remote = NULL;
+  gs_free gchar *branch = NULL;
+  gs_free gchar *refspec = NULL;
+  gchar *pullrefs[] = { NULL, NULL };
+  gchar *csum = NULL;
+  GMainContext *task_context = g_main_context_new ();
+  gs_unref_variant GVariant *commit = NULL;
+
+  g_main_context_push_thread_default (task_context);
+
+  if (!ostree_daemon_resolve_upgrade (ostree, repo,
+                                      &remote, &branch, NULL, &error))
+    goto error;
+
+  pullrefs[0] = branch;
+
+  // FIXME: upstream ostree_repo_pull has an unbalanced
+  // g_main_context_get_thread_default/g_main_context_unref
+  // instead of
+  // g_main_context_ref_thread_default/g_main_context_unref
+  // which breaks our g_main_context_unref down in cleanup:
+  if (!ostree_repo_pull (repo, remote, pullrefs, flags, NULL, cancel, &error))
+    goto error;
+
+  refspec = g_strdup_printf ("%s:%s", remote, branch);
+
+  if (!ostree_repo_resolve_rev (repo, refspec, TRUE, &csum, &error))
+    goto error;
+
+  if (!csum)
+    {
+      if (!error)
+        g_set_error (&error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                     "Server does not have image '%s'", refspec);
+      goto error;
+    }
+
+  if (!ostree_repo_load_variant (repo, OSTREE_OBJECT_TYPE_COMMIT,
+                                 csum, &commit, &error))
+    goto error;
+
+  // returning the sha256 sum of the just-fetched rev:
+  g_task_return_pointer (task, csum, g_free);
+  goto cleanup;
+
+ error:
+  g_task_return_error (task, error);
+
+ cleanup:
+  g_main_context_pop_thread_default (task_context);
+  g_main_context_unref (task_context);
+  return;
+}
+
+gboolean
+handle_poll (OTDOSTree             *ostree,
+             GDBusMethodInvocation *call,
+             gpointer               user_data)
+{
+  OstreeRepo *repo = OSTREE_REPO (user_data);
+  GTask *task = NULL;
+  OTDState state = otd_ostree_get_state (ostree);
+  // gboolean poll_ok = FALSE;
+
+  switch (state)
+    {
+      case OTD_STATE_READY:
+      case OTD_STATE_UPDATE_AVAILABLE:
+      case OTD_STATE_UPDATE_READY:
+      case OTD_STATE_ERROR:
+        break;
+      default:
+        g_dbus_method_invocation_return_error (call,
+          OTD_ERROR, OTD_ERROR_WRONG_STATE,
+          "Can't call Poll() while in state %s", otd_state_to_string (state));
+        goto bail;
+    }
+
+  ostree_daemon_set_state (ostree, OTD_STATE_POLLING);
+  task = g_task_new (ostree, NULL, metadata_fetch_finished, g_object_ref (repo));
+  g_task_set_task_data (task, g_object_ref (repo), g_object_unref);
+  g_task_run_in_thread (task, metadata_fetch);
+
+  otd_ostree_complete_poll (ostree, call);
+
+bail:
+  return TRUE;
+}

--- a/src/daemon/ostree-daemon-poll.h
+++ b/src/daemon/ostree-daemon-poll.h
@@ -1,0 +1,35 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#pragma once
+
+#include "ostree-daemon-generated.h"
+#include "ostree-daemon-util.h"
+#include <ostree.h>
+
+G_BEGIN_DECLS
+
+gboolean handle_poll (OTDOSTree             *ostree,
+                      GDBusMethodInvocation *call,
+                      gpointer               user_data);
+
+G_END_DECLS

--- a/src/daemon/ostree-daemon-service.xslt
+++ b/src/daemon/ostree-daemon-service.xslt
@@ -1,0 +1,22 @@
+<xsl:stylesheet version = '1.0'
+     xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
+  <xsl:output omit-xml-declaration="yes"/>
+  <xsl:template match="/node">
+    <xsl:text>[D-BUS Service]
+Name=</xsl:text>
+    <xsl:apply-templates /><xsl:text>
+Exec=/usr/bin/ostree-daemon
+User=root</xsl:text>
+  </xsl:template>
+
+
+  <xsl:template match="//interface[@name]">
+    <xsl:variable name="if"><xsl:value-of select="@name"/></xsl:variable>
+    <xsl:value-of select="$if"/><xsl:text></xsl:text>
+  </xsl:template>
+
+  <!-- this strips out all the non-tag text so that
+       we don't emit lots of unwanted inter-tag whitespace  -->
+  <xsl:template match="text()"/>
+
+</xsl:stylesheet> 

--- a/src/daemon/ostree-daemon-util.c
+++ b/src/daemon/ostree-daemon-util.c
@@ -1,0 +1,164 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#include "ostree-daemon-util.h"
+#include "ostree-daemon.h"
+#include "ostree-deployment.h"
+
+static const GDBusErrorEntry otd_error_entries[] = {
+  { OTD_ERROR_WRONG_STATE, "org.gnome.OSTree.Error.WrongState" }
+};
+
+/* Ensure that every error code has an associated D-Bus error name */
+G_STATIC_ASSERT (G_N_ELEMENTS (otd_error_entries) == OTD_N_ERRORS);
+
+GQuark
+otd_error_quark (void)
+{
+  static volatile gsize quark_volatile = 0;
+  g_dbus_error_register_error_domain ("otd-error-quark",
+                                      &quark_volatile,
+                                      otd_error_entries,
+                                      G_N_ELEMENTS (otd_error_entries));
+  return (GQuark) quark_volatile;
+}
+
+static const gchar * state_str[] = {
+   "None",
+   "Ready",
+   "Error",
+   "Polling",
+   "UpdateAvailable",
+   "Fetching",
+   "UpdateReady",
+   "ApplyUpdate",
+   "UpdateApplied" };
+
+G_STATIC_ASSERT (G_N_ELEMENTS (state_str) == OTD_N_STATES);
+
+const gchar * otd_state_to_string (OTDState state)
+{
+  g_assert (state < OTD_N_STATES);
+
+  return state_str[state];
+};
+
+
+void
+ostree_daemon_set_state (OTDOSTree *ostree, OTDState state)
+{
+  otd_ostree_set_state (ostree, state);
+  otd_ostree_emit_state_changed (ostree, state);
+}
+
+void
+ostree_daemon_set_error (OTDOSTree *ostree, GError *error)
+{
+  gint code = error ? error->code : -1;
+  const gchar *msg = (error && error->message) ? error->message : "Unspecified";
+
+  otd_ostree_set_error_code (ostree, code);
+  otd_ostree_set_error_message (ostree, msg);
+  ostree_daemon_set_state (ostree, OTD_STATE_ERROR);
+}
+
+OstreeRepo *
+ostree_daemon_local_repo (void)
+{
+  OstreeRepo *ret = NULL;
+  GError *error = NULL;
+
+  gs_unref_object OstreeRepo *repo = ostree_repo_new_default ();
+
+  if (!ostree_repo_open (repo, NULL, &error))
+    {
+      GFile *file = ostree_repo_get_path (repo);
+      gs_free gchar *path = g_file_get_path (file);
+
+      g_warning ("Repo at '%s' is not Ok (%s)",
+                 path ? path : "", error->message);
+
+      g_clear_error (&error);
+      g_assert_not_reached ();
+    }
+
+  ret = repo;
+  repo = NULL;
+
+  return ret;
+}
+
+gboolean
+ostree_daemon_resolve_upgrade (OTDOSTree  *ostree,
+                               OstreeRepo *repo,
+                               gchar     **upgrade_remote,
+                               gchar     **upgrade_ref,
+                               gchar     **booted_checksum,
+                               GError    **error)
+{
+  gboolean ret = FALSE;
+  // gint cur_bootversion = -1;
+  gs_free gchar *o_refspec = NULL;
+  gs_free gchar *o_remote = NULL;
+  gs_free gchar *o_ref = NULL;
+  gs_unref_ptrarray GPtrArray *cur_deployments = NULL;
+  // gs_unref_object OstreeDeployment *old_deployment = NULL;
+  gs_unref_object OstreeDeployment *merge_deployment = NULL;
+  // gs_unref_object GFile *sysroot = g_file_new_for_path ("/");
+  const gchar *osname;
+  const gchar *booted;
+  GKeyFile *origin;
+
+  OstreeSysroot *sysroot = ostree_sysroot_new_default ();
+
+  if (!ostree_sysroot_load (sysroot, NULL, error))
+    goto out;
+
+  merge_deployment = ostree_sysroot_get_merge_deployment (sysroot, NULL);
+  osname = ostree_deployment_get_osname (merge_deployment);
+  origin = ostree_deployment_get_origin (merge_deployment);
+  booted = ostree_deployment_get_csum (merge_deployment);
+
+  if (!origin)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   "No origin found for %s (%s), cannot upgrade",
+                   osname, booted);
+      goto out;
+    }
+
+  o_refspec = g_key_file_get_string (origin, "origin", "refspec", NULL);
+
+  if (!ostree_parse_refspec (o_refspec, &o_remote, &o_ref, error))
+    goto out;
+
+  ret = (o_remote && o_ref && *o_remote && *o_ref);
+
+  shuffle_out_values (upgrade_remote, o_remote, NULL);
+  shuffle_out_values (upgrade_ref, o_ref, NULL);
+
+  if (booted_checksum)
+    *booted_checksum = g_strdup (booted);
+
+  out:
+    return ret;
+}

--- a/src/daemon/ostree-daemon-util.h
+++ b/src/daemon/ostree-daemon-util.h
@@ -1,0 +1,73 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#pragma once
+
+#include "ostree-daemon-generated.h"
+#include "libgsystem.h"
+#include <glib.h>
+#include <ostree.h>
+
+#define shuffle_out_values(out,local,null) \
+    ({ if (out) { *out = local; local = null; } })
+
+#define message(_f, ...) \
+  g_log (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, _f, ## __VA_ARGS__)
+
+G_BEGIN_DECLS
+
+#define OTD_ERROR (otd_error_quark())
+GQuark otd_error_quark (void);
+
+typedef enum {
+  OTD_ERROR_WRONG_STATE,
+  OTD_N_ERRORS /*< skip >*/
+} OTDError;
+
+typedef enum {
+  OTD_STATE_NONE = 0,
+  OTD_STATE_READY,
+  OTD_STATE_ERROR,
+  OTD_STATE_POLLING,
+  OTD_STATE_UPDATE_AVAILABLE,
+  OTD_STATE_FETCHING,
+  OTD_STATE_UPDATE_READY,
+  OTD_STATE_APPLYING_UPDATE,
+  OTD_STATE_UPDATE_APPLIED,
+  OTD_N_STATES,
+} OTDState;
+
+const gchar *otd_state_to_string (OTDState state);
+void ostree_daemon_set_state (OTDOSTree *ostree, OTDState state);
+
+void ostree_daemon_set_error (OTDOSTree *ostree, GError *error);
+
+OstreeRepo * ostree_daemon_local_repo (void);
+
+gboolean ostree_daemon_resolve_upgrade (OTDOSTree  *ostree,
+                                        OstreeRepo *repo,
+                                        gchar     **upgrade_remote,
+                                        gchar     **upgrade_ref,
+                                        gchar     **booted_checksum,
+                                        GError    **error);
+
+G_END_DECLS

--- a/src/daemon/ostree-daemon.c
+++ b/src/daemon/ostree-daemon.c
@@ -1,0 +1,145 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#include "ostree-daemon.h"
+#include "ostree-daemon-generated.h"
+#include "ostree-daemon-util.h"
+#include "ostree-daemon-poll.h"
+#include "ostree-daemon-fetch.h"
+#include "ostree-daemon-apply.h"
+#include <ostree.h>
+#include <gio/gio.h>
+
+static GDBusObjectManagerServer *manager = NULL;
+
+static void
+on_bus_acquired (GDBusConnection *connection,
+                 const gchar     *name,
+                 gpointer         user_data)
+{
+  OTDObjectSkeleton *object = NULL;
+  OTDOSTree *ostree = NULL;
+  OstreeRepo *repo = OSTREE_REPO (user_data);
+  GError *error = NULL;
+  OTDState state;
+
+  gs_free gchar *src = NULL;
+  gs_free gchar *ref = NULL;
+  gs_free gchar *sum = NULL;
+
+  message ("Acquired a message bus connection\n");
+
+  /* Create a new org.freedesktop.DBus.ObjectManager rooted at /org/gnome */
+  manager = g_dbus_object_manager_server_new ("/org/gnome");
+  object  = otd_object_skeleton_new ("/org/gnome/OSTree");
+
+  /* Make the newly created object export the interface org.gnome.OSTree
+     (note that @skeleton takes its own reference to @ostree). */
+  ostree  = otd_ostree_skeleton_new ();
+  otd_object_skeleton_set_ostree (object, ostree);
+  g_object_unref (ostree);
+
+  /* Handle the various DBus methods: */
+  g_signal_connect (ostree, "handle-fetch", G_CALLBACK (handle_fetch), repo);
+  g_signal_connect (ostree, "handle-poll",  G_CALLBACK (handle_poll), repo);
+  g_signal_connect (ostree, "handle-apply", G_CALLBACK (handle_apply), repo);
+
+  if (ostree_daemon_resolve_upgrade (ostree, repo, NULL, NULL, &sum, &error))
+    {
+      otd_ostree_set_current_id (ostree, sum);
+      otd_ostree_set_download_size (ostree, 0);
+      otd_ostree_set_downloaded_bytes (ostree, 0);
+      otd_ostree_set_unpacked_size (ostree, 0);
+      otd_ostree_set_error_code (ostree, 0);
+      otd_ostree_set_error_message (ostree, "");
+      otd_ostree_set_update_id (ostree, "");
+      state = OTD_STATE_READY;
+    }
+  else
+    {
+      otd_ostree_set_error_code (ostree, error->code);
+      otd_ostree_set_error_message (ostree, error->message);
+      state = OTD_STATE_ERROR;
+    }
+
+  // We are deliberately not emitting a signal here: This
+  // isn't a state change, it's our initial state:
+  otd_ostree_set_state (ostree, state);
+
+  /* Export the object (@manager takes its own reference to @object) */
+  g_dbus_object_manager_server_export (manager, G_DBUS_OBJECT_SKELETON (object));
+  g_object_unref (object);
+
+  /* Export all objects */
+  message ("Exporting objects");
+  g_dbus_object_manager_server_set_connection (manager, connection);
+}
+
+static void
+on_name_acquired (GDBusConnection *connection,
+                  const gchar     *name,
+                  gpointer         user_data)
+{
+  message ("Acquired the name %s\n", name);
+}
+
+static void
+on_name_lost (GDBusConnection *connection,
+              const gchar     *name,
+              gpointer         user_data)
+{
+  message ("Lost the name %s\n", name);
+}
+
+gint
+main (gint argc, gchar *argv[])
+{
+  GMainLoop *loop = NULL;
+  OstreeRepo *repo = NULL;
+  guint id = 0;
+
+#ifndef GLIB_VERSION_2_36
+  g_type_init ();
+#endif
+  g_set_prgname (argv[0]);
+
+  repo = ostree_daemon_local_repo ();
+  loop = g_main_loop_new (NULL, FALSE);
+  id = g_bus_own_name (G_BUS_TYPE_SYSTEM,
+                       "org.gnome.OSTree",
+                       G_BUS_NAME_OWNER_FLAGS_ALLOW_REPLACEMENT |
+                       G_BUS_NAME_OWNER_FLAGS_REPLACE,
+                       on_bus_acquired,
+                       on_name_acquired,
+                       on_name_lost,
+                       repo,
+                       NULL);
+
+  g_main_loop_run (loop);
+
+  g_bus_unown_name (id);
+  g_main_loop_unref (loop);
+
+  g_object_unref (repo);
+
+  return 0;
+}

--- a/src/daemon/ostree-daemon.h
+++ b/src/daemon/ostree-daemon.h
@@ -1,0 +1,26 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2013 Collabora Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Author: Vivek Dasmohapatra <vivek@etla.org>
+ */
+
+#pragma once
+
+#include <glib.h>
+

--- a/src/daemon/ostree-daemon.xml
+++ b/src/daemon/ostree-daemon.xml
@@ -1,0 +1,32 @@
+<node>
+  <interface name="org.gnome.OSTree">
+    <method name="Poll" ></method>
+    <method name="Fetch"></method>
+    <method name="Apply"></method>
+    
+    <property name="State"            type="u" access="read"/>
+    <property name="UpdateID"         type="s" access="read"/>
+    <property name="CurrentID"        type="s" access="read"/>
+    <property name="UpdateLabel"      type="s" access="read"/>
+    <property name="UpdateMessage"    type="s" access="read"/>
+    <property name="DownloadSize"     type="x" access="read"/>
+    <property name="DownloadedBytes"  type="x" access="read"/>
+    <property name="UnpackedSize"     type="x" access="read"/>
+    <property name="FullDownloadSize" type="x" access="read"/>
+    <property name="FullUnpackedSize" type="x" access="read"/>
+    <property name="ErrorCode"        type="u" access="read"/>
+    <property name="ErrorMessage"     type="s" access="read"/>
+    
+    <signal name="StateChanged">
+      <arg type="u" name="state"/>
+    </signal>
+
+    <signal name="Progress">
+      <arg type="x" name="fetched"/>
+      <arg type="x" name="expected"/>
+    </signal>
+
+  </interface>
+</node>
+
+


### PR DESCRIPTION
The ostree daemon should be fully implemented and compatible with
the version on the Endless branch. It is no longer linking in
anything from ostree except what is provided by libostree.