### PR TITLE
Compat bugfixes

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1306,7 +1306,7 @@ enqueue_one_object_request (OtPullData        *pull_data,
   expected_max_size_p = g_hash_table_lookup (pull_data->expected_commit_sizes, checksum);
   if (expected_max_size_p)
     expected_max_size = *expected_max_size_p;
-  else if (is_meta)
+  else if (is_meta && fetchtype != OSTREE_FETCH_OBJECT_COMPAT_SIZES)
     expected_max_size = OSTREE_MAX_METADATA_SIZE;
   else
     expected_max_size = 0;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1103,8 +1103,8 @@ scan_commit_object (OtPullData         *pull_data,
   g_variant_get_child (commit, 6, "@ay", &tree_contents_csum);
   g_variant_get_child (commit, 7, "@ay", &tree_meta_csum);
 
-  // If this is a metadata only pull, don't grab the top dirtree/dirmeta:
-  if (!(pull_data->flags & OSTREE_REPO_PULL_FLAGS_METADATA))
+  // If this is a commit only pull, don't grab the top dirtree/dirmeta:
+  if (!(pull_data->flags & OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY))
     {
       if (!scan_one_metadata_object_c (pull_data,
                                        ostree_checksum_bytes_peek (tree_contents_csum),
@@ -2248,7 +2248,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     }
 
   /* iterate over commits fetched and delete any commitpartial files */
-  if (!(dir_to_pull || (pull_data->flags & OSTREE_REPO_PULL_FLAGS_METADATA)))
+  if (!(dir_to_pull || (pull_data->flags & OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY)))
     {
       g_hash_table_iter_init (&hash_iter, requested_refs_to_fetch);
       while (g_hash_table_iter_next (&hash_iter, &key, &value))

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -664,12 +664,12 @@ gboolean ostree_repo_prune (OstreeRepo        *self,
  * OstreeRepoPullFlags:
  * @OSTREE_REPO_PULL_FLAGS_NONE: No special options for pull
  * @OSTREE_REPO_PULL_FLAGS_MIRROR: Write out refs suitable for mirrors
- * @OSTREE_REPO_PULL_FLAGS_METADATA: Only fetch the commit object + any metadata
+ * @OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY: Only fetch the commit object + global metadata
  */
 typedef enum {
   OSTREE_REPO_PULL_FLAGS_NONE,
   OSTREE_REPO_PULL_FLAGS_MIRROR,
-  OSTREE_REPO_PULL_FLAGS_METADATA
+  OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY
 } OstreeRepoPullFlags;
 
 gboolean ostree_repo_pull (OstreeRepo             *self,

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1829,9 +1829,13 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
                                       cancellable, error))
     goto out;
 
+  /* Disable so that the /endless symlink can be created on boot */
+  /*
   if (!ostree_sysroot_deployment_set_mutable (self, new_deployment, FALSE,
                                               cancellable, error))
     goto out;
+  */
+
 
   { ostree_cleanup_sepolicy_fscreatecon gpointer dummy = NULL;
 

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -31,14 +31,14 @@ static gboolean opt_disable_fsync;
 static gboolean opt_mirror;
 static char* opt_subpath;
 static int opt_depth = 0;
-static gboolean opt_metadata;
+static gboolean opt_commit_only;
  
  static GOptionEntry options[] = {
    { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
    { "mirror", 0, 0, G_OPTION_ARG_NONE, &opt_mirror, "Write refs suitable for a mirror", NULL },
    { "subpath", 0, 0, G_OPTION_ARG_STRING, &opt_subpath, "Only pull the provided subpath", NULL },
    { "depth", 0, 0, G_OPTION_ARG_INT, &opt_depth, "Traverse DEPTH parents (-1=infinite) (default: 0)", "DEPTH" },
-   { "metadata", 'm', 0, G_OPTION_ARG_NONE, &opt_metadata, "Download only the metadata", NULL },
+   { "commit-only", 0, 0, G_OPTION_ARG_NONE, &opt_commit_only, "Only pull the commit object", NULL },
    { NULL }
  };
 
@@ -89,8 +89,8 @@ ostree_builtin_pull (int argc, char **argv, GCancellable *cancellable, GError **
   if (opt_mirror)
     pullflags |= OSTREE_REPO_PULL_FLAGS_MIRROR;
 
-  if (opt_metadata)
-    pullflags |= OSTREE_REPO_PULL_FLAGS_METADATA;
+  if (opt_commit_only)
+    pullflags |= OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY;
 
   if (strchr (argv[1], ':') == NULL)
     {

--- a/src/ostree/ot-builtin-size-summary.c
+++ b/src/ostree/ot-builtin-size-summary.c
@@ -88,7 +88,7 @@ ostree_builtin_size_summary (int argc, char **argv, GCancellable *cancellable, G
   // nothing in the cache, but try and fetch it if it's a remote refspec:
   if (!revision && remote)
     {
-      OstreeRepoPullFlags flags = OSTREE_REPO_PULL_FLAGS_METADATA;
+      OstreeRepoPullFlags flags = OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY;
       gchar *pullrefs[] = { (gchar *) ref, NULL };
 
       if (!ostree_repo_pull (repo, remote, pullrefs, flags, NULL, cancellable, error))


### PR DESCRIPTION
Fix three issues:
* Immutable filesystem root prevented creating /endless symlink
* Legacy size metadata is large, which was causing daemon poll to fail
* Metadata only pull mode was ambiguously named