### PR TITLE
Handle ConditionNeedsUpdate=/etc or /var

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1773,6 +1773,7 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
   g_autoptr(GFile) tree_kernel_path = NULL;
   g_autoptr(GFile) tree_initramfs_path = NULL;
   glnx_fd_close int deployment_dfd = -1;
+  glnx_fd_close int deployment_var_dfd = -1;
   glnx_unref_object OstreeSePolicy *sepolicy = NULL;
   g_autofree char *new_bootcsum = NULL;
   glnx_unref_object OstreeBootconfigParser *bootconfig = NULL;
@@ -1846,6 +1847,18 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
       g_prefix_error (error, "During /etc merge: ");
       goto out;
     }
+
+  /* Ensure that the new deployment does not have /etc/.updated or
+   * /var/.updated so that systemd ConditionNeedsUpdate=/etc|/var
+   * services run after rebooting.
+   */
+  if (!ot_ensure_unlinked_at (deployment_dfd, "etc/.updated", error))
+    goto out;
+  if (!gs_file_open_dir_fd (deployment_var, &deployment_var_dfd,
+                            cancellable, error))
+    goto out;
+  if (!ot_ensure_unlinked_at (deployment_var_dfd, ".updated", error))
+    goto out;
 
   g_clear_object (&self->sepolicy);
   self->sepolicy = g_object_ref (sepolicy);

--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -742,7 +742,6 @@ merge_configuration (OstreeSysroot         *sysroot,
   glnx_unref_object OstreeSePolicy *sepolicy = NULL;
   gboolean etc_exists;
   gboolean usretc_exists;
-  int deployment_etc_fd = -1;
 
   if (previous_deployment)
     {
@@ -817,20 +816,9 @@ merge_configuration (OstreeSysroot         *sysroot,
         goto out;
     }
 
-  /* Ensure that the new deployment does not have /etc/.updated so that
-   * systemd ConditionNeedsUpdate=/etc services run after rebooting.
-   */
-  if (!gs_file_open_dir_fd (deployment_etc_path, &deployment_etc_fd,
-                            cancellable, error))
-    goto out;
-  if (!ot_ensure_unlinked_at (deployment_etc_fd, ".updated", error))
-    goto out;
-
   ret = TRUE;
   gs_transfer_out_value (out_sepolicy, &sepolicy);
  out:
-  if (deployment_etc_fd != -1)
-    (void) close (deployment_etc_fd);
   return ret;
 }
 


### PR DESCRIPTION
Delete both /etc/.updated and /var/.updated on new deployments to support both typical conditions used by systemd units.

[endlessm/eos-shell#5426]