### PR TITLE
Revert "Revert "Don't make the root immutable""

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1867,9 +1867,13 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
                                       cancellable, error))
     goto out;
 
+  /* Disable so that the /endless symlink can be created on boot */
+  /*
   if (!ostree_sysroot_deployment_set_mutable (self, new_deployment, FALSE,
                                               cancellable, error))
     goto out;
+  */
+
 
   { ostree_cleanup_sepolicy_fscreatecon gpointer dummy = NULL;
 


### PR DESCRIPTION
This reverts commit be1131def9a53804757866b448b6bebc30de7000.
Unfortunately, this breaks systemd's readahead implementation, which
tries to create /.readahead and /.readahead.new.

[endlessm/eos-shell#5190]