### PR TITLE
Shell/5640

### DIFF
--- a/src/libostree/ostree-repo-static-delta-compilation-analysis.c
+++ b/src/libostree/ostree-repo-static-delta-compilation-analysis.c
@@ -76,20 +76,18 @@ build_content_sizenames_recurse (OstreeRepo                     *repo,
             {
               g_autoptr(GFileInfo) finfo = NULL;
 
-              csizenames = g_new0 (OstreeDeltaContentSizeNames, 1);
-              csizenames->checksum = g_strdup (checksum);
-              
-              /* Transfer ownership so things get cleaned up if we
-               * throw an exception below.
-               */
-              g_hash_table_replace (sizenames_map, csizenames->checksum, csizenames);
-
               if (!ostree_repo_load_file (repo, checksum,
                                           NULL, &finfo, NULL,
                                           cancellable, error))
                 goto out;
-              
+
+              if (g_file_info_get_file_type (finfo) != G_FILE_TYPE_REGULAR)
+                continue;
+
+              csizenames = g_new0 (OstreeDeltaContentSizeNames, 1);
+              csizenames->checksum = g_strdup (checksum);
               csizenames->size = g_file_info_get_size (finfo);
+              g_hash_table_replace (sizenames_map, csizenames->checksum, csizenames);
             }
 
           if (!csizenames->basenames)

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -473,11 +473,7 @@ get_unpacked_unlinked_content (OstreeRepo       *repo,
                               cancellable, error))
     goto out;
 
-  if (g_file_info_get_file_type (ret_finfo) != G_FILE_TYPE_REGULAR)
-    {
-      ret = TRUE;
-      goto out;
-    }
+  g_assert (g_file_info_get_file_type (ret_finfo) == G_FILE_TYPE_REGULAR);
   
   out = g_unix_output_stream_new (fd, FALSE);
   if (g_output_stream_splice (out, istream, G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
@@ -569,13 +565,6 @@ try_content_rollsum (OstreeRepo                       *repo,
   if (!get_unpacked_unlinked_content (repo, to, &tmp_to, &to_finfo,
                                       cancellable, error))
     goto out;
-
-  /* Only try to rollsum regular files obviously */ 
-  if (!(tmp_from && tmp_to))
-    {
-      ret = TRUE;
-      goto out;
-    }
 
   matches = _ostree_compute_rollsum_matches (tmp_from, tmp_to);
 

--- a/src/libostree/ostree-repo-static-delta-compilation.c
+++ b/src/libostree/ostree-repo-static-delta-compilation.c
@@ -523,7 +523,10 @@ try_content_bsdiff (OstreeRepo                       *repo,
 
   /* TODO: make this option configurable.  */
   if (g_bytes_get_size (tmp_to) + g_bytes_get_size (tmp_from) > (200 * (1 << 20)))
-    goto out;
+    {
+      ret = TRUE;
+      goto out;
+    }
 
   ret_bsdiff = g_new0 (ContentBsdiff, 1);
   ret_bsdiff->from_checksum = g_strdup (from);


### PR DESCRIPTION
A few patches, which are already upstream, are needed to ensure deltas are generated without failing.

The first patch avoids failing on large files. The second and third (written by me) avoid comparing symlinks to regular files which fails.
