### PR TITLE
fetcher: Use 0666 (-umask) for temporary files

### DIFF
--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -502,7 +502,7 @@ on_request_sent (GObject        *object,
       else
         oflags |= O_TRUNC;
 
-      fd = openat (pending->self->tmpdir_dfd, pending->out_tmpfile, oflags, 0600);
+      fd = openat (pending->self->tmpdir_dfd, pending->out_tmpfile, oflags, 0666);
       if (fd == -1)
         {
           gs_set_error_from_errno (&local_error, errno);

--- a/tests/test-pull-mirror-summary.sh
+++ b/tests/test-pull-mirror-summary.sh
@@ -50,6 +50,13 @@ assert_file_has_content other-copy/hello-world "hello world another object"
 ostree --repo=repo checkout -U yet-another yet-another-copy
 assert_file_has_content yet-another-copy/yet-another-hello-world "hello world yet another object"
 ostree --repo=repo fsck
+rev=$(ostree --repo=repo rev-parse main)
+find repo/objects -name '*.filez' | while read name; do
+    mode=$(stat -c '%a' "${name}")
+    if test "${mode}" = 600; then
+	assert_not_reached "Content object unreadable by others: ${mode}"
+    fi
+done
 echo "ok pull mirror summary"
 
 if ! ${CMD_PREFIX} ostree --version | grep -q -e '\+gpgme'; then


### PR DESCRIPTION
There's no reason to keep them hidden.  I have a hard policy that
OSTree should *not* be used to carry secrets.  Things like host ssh
private keys should be set up out of band by an OS-external
configuration mechanism such as kickstart, cloud-init, etc.

We also assume that hiding binaries is not very useful as most
attackers would be able to find them on the Internet or (for
subscribed content) acting as a customer.

This fixes a bug with mirroring because we changed to take the
unmodified upstream objects rather than uncompress <-> recompress.

https://bugzilla.gnome.org/show_bug.cgi?id=748959