### PR TITLE
Cherry-pick upstream patches to fix timeout on pull

### DIFF
--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -201,10 +201,10 @@ _ostree_fetcher_init (OstreeFetcher *self)
 
   self->max_outstanding = 3 * max_conns;
 
-  g_signal_connect (self->session, "request-started",
-                    G_CALLBACK (on_request_started), self);
-  g_signal_connect (self->session, "request-unqueued",
-                    G_CALLBACK (on_request_unqueued), self);
+  g_signal_connect_object (self->session, "request-started",
+                           G_CALLBACK (on_request_started), self, 0);
+  g_signal_connect_object (self->session, "request-unqueued",
+                           G_CALLBACK (on_request_unqueued), self, 0);
   
   self->sending_messages = g_hash_table_new_full (NULL, NULL, NULL,
                                                   (GDestroyNotify)g_object_unref);

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -732,6 +732,10 @@ fetch_uri_sync_on_complete (GObject        *object,
   data->done = TRUE;
 }
 
+/* Synchronously request a URI - will iterate the thread-default main
+ * context for historical reasons.  If you don't want that, push a
+ * temporary one.
+ */
 gboolean
 _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
                                        SoupURI        *uri,
@@ -755,8 +759,7 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
   if (g_cancellable_set_error_if_cancelled (cancellable, error))
     return FALSE;
 
-  mainctx = g_main_context_new ();
-  g_main_context_push_thread_default (mainctx);
+  mainctx = g_main_context_ref_thread_default ();
 
   data.done = FALSE;
   data.error = error;
@@ -801,8 +804,6 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
   ret = TRUE;
   *out_contents = g_memory_output_stream_steal_as_bytes (buf);
  out:
-  if (mainctx)
-    g_main_context_pop_thread_default (mainctx);
   g_clear_object (&(data.result_stream));
   return ret;
 }

--- a/src/libostree/ostree-fetcher.c
+++ b/src/libostree/ostree-fetcher.c
@@ -715,7 +715,7 @@ _ostree_fetcher_bytes_transferred (OstreeFetcher       *self)
 typedef struct
 {
   GInputStream   *result_stream;
-  GMainLoop      *loop;
+  gboolean         done;
   GError         **error;
 }
 FetchUriSyncData;
@@ -729,7 +729,7 @@ fetch_uri_sync_on_complete (GObject        *object,
 
   data->result_stream = ostree_fetcher_stream_uri_finish ((OstreeFetcher*)object,
                                                           result, data->error);
-  g_main_loop_quit (data->loop);
+  data->done = TRUE;
 }
 
 gboolean
@@ -738,7 +738,6 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
                                        gboolean        add_nul,
                                        gboolean        allow_noent,
                                        GBytes         **out_contents,
-                                       GMainLoop      *loop,
                                        guint64        max_size,
                                        GCancellable   *cancellable,
                                        GError         **error)
@@ -747,6 +746,7 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
   const guint8 nulchar = 0;
   g_autofree char *ret_contents = NULL;
   g_autoptr(GMemoryOutputStream) buf = NULL;
+  g_autoptr(GMainContext) mainctx = NULL;
   FetchUriSyncData data;
   g_assert (error != NULL);
 
@@ -755,7 +755,10 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
   if (g_cancellable_set_error_if_cancelled (cancellable, error))
     return FALSE;
 
-  data.loop = loop;
+  mainctx = g_main_context_new ();
+  g_main_context_push_thread_default (mainctx);
+
+  data.done = FALSE;
   data.error = error;
 
   ostree_fetcher_stream_uri_async (fetcher, uri,
@@ -763,8 +766,9 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
                                    OSTREE_FETCHER_DEFAULT_PRIORITY,
                                    cancellable,
                                    fetch_uri_sync_on_complete, &data);
+  while (!data.done)
+    g_main_context_iteration (mainctx, TRUE);
 
-  g_main_loop_run (loop);
   if (!data.result_stream)
     {
       if (allow_noent)
@@ -797,6 +801,8 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
   ret = TRUE;
   *out_contents = g_memory_output_stream_steal_as_bytes (buf);
  out:
+  if (mainctx)
+    g_main_context_pop_thread_default (mainctx);
   g_clear_object (&(data.result_stream));
   return ret;
 }

--- a/src/libostree/ostree-fetcher.h
+++ b/src/libostree/ostree-fetcher.h
@@ -87,7 +87,6 @@ gboolean _ostree_fetcher_request_uri_to_membuf (OstreeFetcher *fetcher,
                                                 gboolean       add_nul,
                                                 gboolean       allow_noent,
                                                 GBytes         **out_contents,
-                                                GMainLoop      *loop,
                                                 guint64        max_size,
                                                 GCancellable   *cancellable,
                                                 GError         **error);

--- a/src/libostree/ostree-metalink.c
+++ b/src/libostree/ostree-metalink.c
@@ -648,8 +648,10 @@ ostree_metalink_request_finish (OstreeMetalink         *self,
   if (g_task_propagate_boolean ((GTask*)result, error))
     {
       g_assert_cmpint (request->current_url_index, <, request->urls->len);
-      *out_target_uri = request->urls->pdata[request->current_url_index];
-      *out_data = g_strdup (request->result);
+      if (out_target_uri != NULL)
+        *out_target_uri = request->urls->pdata[request->current_url_index];
+      if (out_data != NULL)
+        *out_data = g_strdup (request->result);
       return TRUE;
     }
   else
@@ -708,7 +710,9 @@ _ostree_metalink_request_sync (OstreeMetalink        *self,
   data.out_data = out_data;
   data.loop = loop;
   data.error = error;
-  *fetching_sync_uri = _ostree_metalink_get_uri (self);
+
+  if (fetching_sync_uri != NULL)
+    *fetching_sync_uri = _ostree_metalink_get_uri (self);
 
   request->metalink = g_object_ref (self);
   request->urls = g_ptr_array_new_with_free_func ((GDestroyNotify) soup_uri_free);

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -51,7 +51,6 @@ OstreeMetalink *_ostree_metalink_new (OstreeFetcher  *fetcher,
 SoupURI *_ostree_metalink_get_uri (OstreeMetalink         *self);
 
 gboolean _ostree_metalink_request_sync (OstreeMetalink        *self,
-                                        GMainLoop             *loop,
                                         SoupURI               **out_target_uri,
                                         GBytes                **out_data,
                                         SoupURI               **fetching_sync_uri,

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -53,7 +53,7 @@ SoupURI *_ostree_metalink_get_uri (OstreeMetalink         *self);
 gboolean _ostree_metalink_request_sync (OstreeMetalink        *self,
                                         GMainLoop             *loop,
                                         SoupURI               **out_target_uri,
-                                        char                  **out_data,
+                                        GBytes                **out_data,
                                         SoupURI               **fetching_sync_uri,
                                         GCancellable          *cancellable,
                                         GError                **error);

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "ostree-repo.h"
+#include "ostree-fetcher.h"
 
 G_BEGIN_DECLS
 
@@ -230,6 +231,11 @@ _ostree_repo_get_remote_boolean_option (OstreeRepo  *self,
                                         gboolean     default_value,
                                         gboolean    *out_value,
                                         GError     **error);
+
+OstreeFetcher *
+_ostree_repo_remote_new_fetcher (OstreeRepo  *self,
+                                 const char  *remote_name,
+                                 GError     **error);
 
 OstreeGpgVerifyResult *
 _ostree_repo_gpg_verify_with_metadata (OstreeRepo          *self,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1765,8 +1765,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   gboolean ret = FALSE;
   GHashTableIter hash_iter;
   gpointer key, value;
-  gboolean tls_permissive = FALSE;
-  OstreeFetcherConfigFlags fetcher_flags = 0;
   g_autofree char *remote_key = NULL;
   g_autofree char *path = NULL;
   g_autofree char *baseurl = NULL;
@@ -1856,84 +1854,13 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
   pull_data->phase = OSTREE_PULL_PHASE_FETCHING_REFS;
 
-  if (!_ostree_repo_get_remote_boolean_option (self,
-                                               remote_name_or_baseurl, "tls-permissive",
-                                               FALSE, &tls_permissive, error))
+  pull_data->fetcher = _ostree_repo_remote_new_fetcher (self, remote_name_or_baseurl, error);
+  if (pull_data->fetcher == NULL)
     goto out;
-  if (tls_permissive)
-    fetcher_flags |= OSTREE_FETCHER_FLAGS_TLS_PERMISSIVE;
 
   pull_data->tmpdir_dfd = pull_data->repo->tmp_dir_fd;
-  pull_data->fetcher = _ostree_fetcher_new (pull_data->tmpdir_dfd, fetcher_flags);
   requested_refs_to_fetch = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
   commits_to_fetch = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
-
-  {
-    g_autofree char *tls_client_cert_path = NULL;
-    g_autofree char *tls_client_key_path = NULL;
-
-    if (!_ostree_repo_get_remote_option (self,
-                                         remote_name_or_baseurl, "tls-client-cert-path",
-                                         NULL, &tls_client_cert_path, error))
-      goto out;
-    if (!_ostree_repo_get_remote_option (self,
-                                         remote_name_or_baseurl, "tls-client-key-path",
-                                         NULL, &tls_client_key_path, error))
-      goto out;
-
-    if ((tls_client_cert_path != NULL) != (tls_client_key_path != NULL))
-      {
-        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                     "remote \"%s\" must specify both \"tls-client-cert-path\" and \"tls-client-key-path\"",
-                     remote_name_or_baseurl);
-        goto out;
-      }
-    else if (tls_client_cert_path)
-      {
-        g_autoptr(GTlsCertificate) client_cert = NULL;
-
-        g_assert (tls_client_key_path);
-
-        client_cert = g_tls_certificate_new_from_files (tls_client_cert_path,
-                                                        tls_client_key_path,
-                                                        error);
-        if (!client_cert)
-          goto out;
-
-        _ostree_fetcher_set_client_cert (pull_data->fetcher, client_cert);
-      }
-  }
-
-  {
-    g_autofree char *tls_ca_path = NULL;
-    g_autoptr(GTlsDatabase) db = NULL;
-
-    if (!_ostree_repo_get_remote_option (self,
-                                         remote_name_or_baseurl, "tls-ca-path",
-                                         NULL, &tls_ca_path, error))
-      goto out;
-
-    if (tls_ca_path)
-      {
-        db = g_tls_file_database_new (tls_ca_path, error);
-        if (!db)
-          goto out;
-        
-        _ostree_fetcher_set_tls_database (pull_data->fetcher, db);
-      }
-  }
-
-  {
-    g_autofree char *http_proxy = NULL;
-
-    if (!_ostree_repo_get_remote_option (self,
-                                         remote_name_or_baseurl, "proxy",
-                                         NULL, &http_proxy, error))
-      goto out;
-
-    if (http_proxy)
-      _ostree_fetcher_set_proxy (pull_data->fetcher, http_proxy);
-  }
 
   if (!_ostree_repo_get_remote_option (self,
                                        remote_name_or_baseurl, "metalink",

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -97,8 +97,6 @@ typedef struct {
 
   GError      **async_error;
   gboolean      caught_error;
-
-  GQueue scan_object_queue;
 } OtPullData;
 
 typedef enum {
@@ -125,26 +123,24 @@ typedef struct {
   char *expected_checksum;
 } FetchStaticDeltaData;
 
-typedef struct {
-  guchar csum[32];
-  OstreeObjectType objtype;
-  guint recursion_depth;
-} ScanObjectQueueData;
-
 static SoupURI *
 suburi_new (SoupURI   *base,
             const char *first,
             ...) G_GNUC_NULL_TERMINATED;
 
-static void queue_scan_one_metadata_object (OtPullData         *pull_data,
-                                            const char         *csum,
-                                            OstreeObjectType    objtype,
-                                            guint               recursion_depth);
+static gboolean scan_one_metadata_object (OtPullData         *pull_data,
+                                          const char         *csum,
+                                          OstreeObjectType    objtype,
+                                          guint               recursion_depth,
+                                          GCancellable       *cancellable,
+                                          GError            **error);
 
-static void queue_scan_one_metadata_object_c (OtPullData         *pull_data,
-                                              const guchar       *csum,
-                                              OstreeObjectType    objtype,
-                                              guint               recursion_depth);
+static gboolean scan_one_metadata_object_c (OtPullData         *pull_data,
+                                            const guchar       *csum,
+                                            OstreeObjectType    objtype,
+                                            guint               recursion_depth,
+                                            GCancellable       *cancellable,
+                                            GError            **error);
 
 static SoupURI *
 suburi_new (SoupURI   *base,
@@ -271,8 +267,7 @@ check_outstanding_requests_handle_error (OtPullData          *pull_data,
   gboolean current_write_idle = (pull_data->n_outstanding_metadata_write_requests == 0 &&
                                  pull_data->n_outstanding_content_write_requests == 0 &&
                                  pull_data->n_outstanding_deltapart_write_requests == 0 );
-  gboolean current_scan_idle = g_queue_is_empty (&pull_data->scan_object_queue);
-  gboolean current_idle = current_fetch_idle && current_write_idle && current_scan_idle;
+  gboolean current_idle = current_fetch_idle && current_write_idle;
 
   throw_async_error (pull_data, error);
 
@@ -294,40 +289,10 @@ check_outstanding_requests_handle_error (OtPullData          *pull_data,
 }
 
 static gboolean
-scan_one_metadata_object_c (OtPullData         *pull_data,
-                            const guchar         *csum,
-                            OstreeObjectType    objtype,
-                            guint               recursion_depth,
-                            GCancellable       *cancellable,
-                            GError            **error);
-
-static void
-process_scan_queue (OtPullData *pull_data)
+idle_check_outstanding_requests (gpointer user_data)
 {
-  ScanObjectQueueData *scan_data;
-  GError *error = NULL;
-
-  scan_data = g_queue_pop_head (&pull_data->scan_object_queue);
-  if (!scan_data)
-    return;
-
-  if (scan_one_metadata_object_c (pull_data,
-                                  scan_data->csum,
-                                  scan_data->objtype,
-                                  scan_data->recursion_depth,
-                                  pull_data->cancellable,
-                                  &error))
-    throw_async_error (pull_data, error);
-
-  g_free (scan_data);
-}
-
-static gboolean
-idle_worker (gpointer user_data)
-{
-  process_scan_queue (user_data);
   check_outstanding_requests_handle_error (user_data, NULL);
-  return G_SOURCE_CONTINUE;
+  return FALSE;
 }
 
 typedef struct {
@@ -504,11 +469,16 @@ scan_dirtree_object (OtPullData   *pull_data,
 
       if (subdir_target && strcmp (subdir_target, dirname) != 0)
         continue;
-
-      queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (tree_csum),
-                                        OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1);
-      queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (meta_csum),
-                                        OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1);
+      
+      if (!scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (tree_csum),
+                                       OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1,
+                                       cancellable, error))
+        goto out;
+      
+      if (!scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (meta_csum),
+                                       OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1,
+                                       cancellable, error))
+        goto out;
     }
 
   ret = TRUE;
@@ -741,7 +711,9 @@ on_metadata_written (GObject           *object,
       goto out;
     }
 
-  queue_scan_one_metadata_object_c (pull_data, csum, objtype, 0);
+  if (!scan_one_metadata_object_c (pull_data, csum, objtype, 0,
+                                   pull_data->cancellable, error))
+    goto out;
 
  out:
   pull_data->n_outstanding_metadata_write_requests--;
@@ -1099,8 +1071,11 @@ scan_commit_object (OtPullData         *pull_data,
   have_parent = g_variant_n_children (parent_csum) > 0;
   if (have_parent && pull_data->maxdepth == -1)
     {
-      queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (parent_csum),
-                                        OSTREE_OBJECT_TYPE_COMMIT, recursion_depth + 1);
+      if (!scan_one_metadata_object_c (pull_data,
+                                       ostree_checksum_bytes_peek (parent_csum),
+                                       OSTREE_OBJECT_TYPE_COMMIT, recursion_depth + 1,
+                                       cancellable, error))
+        goto out;
     }
   else if (have_parent && depth > 0)
     {
@@ -1124,8 +1099,11 @@ scan_commit_object (OtPullData         *pull_data,
         {
           g_hash_table_insert (pull_data->commit_to_depth, g_strdup (parent_checksum),
                                GINT_TO_POINTER (parent_depth));
-          queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (parent_csum),
-                                            OSTREE_OBJECT_TYPE_COMMIT, recursion_depth + 1);
+          if (!scan_one_metadata_object_c (pull_data,
+                                           ostree_checksum_bytes_peek (parent_csum),
+                                           OSTREE_OBJECT_TYPE_COMMIT, recursion_depth + 1,
+                                           cancellable, error))
+            goto out;
         }
     }
 
@@ -1135,43 +1113,38 @@ scan_commit_object (OtPullData         *pull_data,
   // If this is a commit only pull, don't grab the top dirtree/dirmeta:
   if (!(pull_data->flags & OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY))
     {
-      queue_scan_one_metadata_object_c (pull_data,
-                                        ostree_checksum_bytes_peek (tree_contents_csum),
-                                        OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1);
-      queue_scan_one_metadata_object_c (pull_data,
-                                        ostree_checksum_bytes_peek (tree_meta_csum),
-                                        OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1);
+      if (!scan_one_metadata_object_c (pull_data,
+                                       ostree_checksum_bytes_peek (tree_contents_csum),
+                                       OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1,
+                                       cancellable, error))
+        goto out;
+
+      if (!scan_one_metadata_object_c (pull_data,
+                                       ostree_checksum_bytes_peek (tree_meta_csum),
+                                       OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1,
+                                       cancellable, error))
+        goto out;
     }
- 
+  
   ret = TRUE;
  out:
   return ret;
 }
 
-static void
-queue_scan_one_metadata_object (OtPullData         *pull_data,
-                                const char         *csum,
-                                OstreeObjectType    objtype,
-                                guint               recursion_depth)
+static gboolean
+scan_one_metadata_object (OtPullData         *pull_data,
+                          const char         *csum,
+                          OstreeObjectType    objtype,
+                          guint               recursion_depth,
+                          GCancellable       *cancellable,
+                          GError            **error)
 {
   guchar buf[32];
   ostree_checksum_inplace_to_bytes (csum, buf);
-  queue_scan_one_metadata_object_c (pull_data, buf, objtype, recursion_depth);
-}
-
-static void
-queue_scan_one_metadata_object_c (OtPullData         *pull_data,
-                                  const guchar         *csum,
-                                  OstreeObjectType    objtype,
-                                  guint               recursion_depth)
-{
-  ScanObjectQueueData *scan_data = g_new0 (ScanObjectQueueData, 1);
-
-  memcpy (scan_data->csum, csum, sizeof (scan_data->csum));
-  scan_data->objtype = objtype;
-  scan_data->recursion_depth = recursion_depth;
-
-  g_queue_push_tail (&pull_data->scan_object_queue, scan_data);
+  
+  return scan_one_metadata_object_c (pull_data, buf, objtype,
+                                     recursion_depth,
+                                     cancellable, error);
 }
 
 static gboolean
@@ -1822,7 +1795,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   pull_data->requested_metadata = g_hash_table_new_full (g_str_hash, g_str_equal,
                                                          (GDestroyNotify)g_free, NULL);
   pull_data->dir = g_strdup (dir_to_pull);
-  g_queue_init (&pull_data->scan_object_queue);
 
   pull_data->start_time = g_get_monotonic_time ();
 
@@ -2224,7 +2196,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   while (g_hash_table_iter_next (&hash_iter, &key, &value))
     {
       const char *commit = value;
-      queue_scan_one_metadata_object (pull_data, commit, OSTREE_OBJECT_TYPE_COMMIT, 0);
+      if (!scan_one_metadata_object (pull_data, commit, OSTREE_OBJECT_TYPE_COMMIT,
+                                     0, pull_data->cancellable, error))
+        goto out;
     }
 
   g_hash_table_iter_init (&hash_iter, requested_refs_to_fetch);
@@ -2251,7 +2225,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       if (!delta_superblock)
         {
           g_debug ("no delta superblock for %s-%s", from_revision ? from_revision : "empty", to_revision);
-          queue_scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT, 0);
+          if (!scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT,
+                                         0, pull_data->cancellable, error))
+            goto out;
         }
       else
         {
@@ -2265,7 +2241,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     }
 
   idle_src = g_idle_source_new ();
-  g_source_set_callback (idle_src, idle_worker, pull_data, NULL);
+  g_source_set_callback (idle_src, idle_check_outstanding_requests, pull_data, NULL);
   g_source_attach (idle_src, pull_data->main_context);
   g_source_unref (idle_src);
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -96,6 +96,9 @@ typedef struct {
 
   GError      **async_error;
   gboolean      caught_error;
+
+  GQueue scan_object_queue;
+  GSource *idle_src;
 } OtPullData;
 
 typedef enum {
@@ -122,17 +125,26 @@ typedef struct {
   char *expected_checksum;
 } FetchStaticDeltaData;
 
+typedef struct {
+  guchar csum[32];
+  OstreeObjectType objtype;
+  guint recursion_depth;
+} ScanObjectQueueData;
+
 static SoupURI *
 suburi_new (SoupURI   *base,
             const char *first,
             ...) G_GNUC_NULL_TERMINATED;
 
-static gboolean scan_one_metadata_object (OtPullData         *pull_data,
-                                          const char         *csum,
-                                          OstreeObjectType    objtype,
-                                          guint               recursion_depth,
-                                          GCancellable       *cancellable,
-                                          GError            **error);
+static void queue_scan_one_metadata_object (OtPullData         *pull_data,
+                                            const char         *csum,
+                                            OstreeObjectType    objtype,
+                                            guint               recursion_depth);
+
+static void queue_scan_one_metadata_object_c (OtPullData         *pull_data,
+                                              const guchar       *csum,
+                                              OstreeObjectType    objtype,
+                                              guint               recursion_depth);
 
 static gboolean scan_one_metadata_object_c (OtPullData         *pull_data,
                                             const guchar       *csum,
@@ -247,7 +259,8 @@ pull_termination_condition (OtPullData          *pull_data)
   gboolean current_write_idle = (pull_data->n_outstanding_metadata_write_requests == 0 &&
                                  pull_data->n_outstanding_content_write_requests == 0 &&
                                  pull_data->n_outstanding_deltapart_write_requests == 0 );
-  gboolean current_idle = current_fetch_idle && current_write_idle;
+  gboolean current_scan_idle = g_queue_is_empty (&pull_data->scan_object_queue);
+  gboolean current_idle = current_fetch_idle && current_write_idle && current_scan_idle;
 
   if (pull_data->caught_error)
     return TRUE;
@@ -285,6 +298,47 @@ check_outstanding_requests_handle_error (OtPullData          *pull_data,
           g_error_free (error);
         }
     }
+}
+
+static gboolean
+idle_worker (gpointer user_data)
+{
+  OtPullData *pull_data = user_data;
+  ScanObjectQueueData *scan_data;
+  GError *error = NULL;
+
+  scan_data = g_queue_pop_head (&pull_data->scan_object_queue);
+  if (!scan_data)
+    {
+      g_clear_pointer (&pull_data->idle_src, (GDestroyNotify) g_source_destroy);
+      return G_SOURCE_REMOVE;
+    }
+
+  scan_one_metadata_object_c (pull_data,
+                              scan_data->csum,
+                              scan_data->objtype,
+                              scan_data->recursion_depth,
+                              pull_data->cancellable,
+                              &error);
+  check_outstanding_requests_handle_error (pull_data, error);
+
+  g_free (scan_data);
+  return G_SOURCE_CONTINUE;
+}
+
+static void
+ensure_idle_queued (OtPullData *pull_data)
+{
+  GSource *idle_src;
+
+  if (pull_data->idle_src)
+    return;
+
+  idle_src = g_idle_source_new ();
+  g_source_set_callback (idle_src, idle_worker, pull_data, NULL);
+  g_source_attach (idle_src, pull_data->main_context);
+  g_source_unref (idle_src);
+  pull_data->idle_src = idle_src;
 }
 
 typedef struct {
@@ -460,16 +514,11 @@ scan_dirtree_object (OtPullData   *pull_data,
 
       if (subdir_target && strcmp (subdir_target, dirname) != 0)
         continue;
-      
-      if (!scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (tree_csum),
-                                       OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1,
-                                       cancellable, error))
-        goto out;
-      
-      if (!scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (meta_csum),
-                                       OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1,
-                                       cancellable, error))
-        goto out;
+
+      queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (tree_csum),
+                                        OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1);
+      queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (meta_csum),
+                                        OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1);
     }
 
   ret = TRUE;
@@ -702,9 +751,7 @@ on_metadata_written (GObject           *object,
       goto out;
     }
 
-  if (!scan_one_metadata_object_c (pull_data, csum, objtype, 0,
-                                   pull_data->cancellable, error))
-    goto out;
+  queue_scan_one_metadata_object_c (pull_data, csum, objtype, 0);
 
  out:
   pull_data->n_outstanding_metadata_write_requests--;
@@ -1062,11 +1109,8 @@ scan_commit_object (OtPullData         *pull_data,
   have_parent = g_variant_n_children (parent_csum) > 0;
   if (have_parent && pull_data->maxdepth == -1)
     {
-      if (!scan_one_metadata_object_c (pull_data,
-                                       ostree_checksum_bytes_peek (parent_csum),
-                                       OSTREE_OBJECT_TYPE_COMMIT, recursion_depth + 1,
-                                       cancellable, error))
-        goto out;
+      queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (parent_csum),
+                                        OSTREE_OBJECT_TYPE_COMMIT, recursion_depth + 1);
     }
   else if (have_parent && depth > 0)
     {
@@ -1090,11 +1134,8 @@ scan_commit_object (OtPullData         *pull_data,
         {
           g_hash_table_insert (pull_data->commit_to_depth, g_strdup (parent_checksum),
                                GINT_TO_POINTER (parent_depth));
-          if (!scan_one_metadata_object_c (pull_data,
-                                           ostree_checksum_bytes_peek (parent_csum),
-                                           OSTREE_OBJECT_TYPE_COMMIT, recursion_depth + 1,
-                                           cancellable, error))
-            goto out;
+          queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (parent_csum),
+                                            OSTREE_OBJECT_TYPE_COMMIT, recursion_depth + 1);
         }
     }
 
@@ -1104,38 +1145,42 @@ scan_commit_object (OtPullData         *pull_data,
   // If this is a commit only pull, don't grab the top dirtree/dirmeta:
   if (!(pull_data->flags & OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY))
     {
-      if (!scan_one_metadata_object_c (pull_data,
-                                       ostree_checksum_bytes_peek (tree_contents_csum),
-                                       OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1,
-                                       cancellable, error))
-        goto out;
-
-      if (!scan_one_metadata_object_c (pull_data,
-                                       ostree_checksum_bytes_peek (tree_meta_csum),
-                                       OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1,
-                                       cancellable, error))
-        goto out;
+      queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (tree_contents_csum),
+                                        OSTREE_OBJECT_TYPE_DIR_TREE, recursion_depth + 1);
+      queue_scan_one_metadata_object_c (pull_data, ostree_checksum_bytes_peek (tree_meta_csum),
+                                        OSTREE_OBJECT_TYPE_DIR_META, recursion_depth + 1);
     }
-  
+
   ret = TRUE;
  out:
   return ret;
 }
 
-static gboolean
-scan_one_metadata_object (OtPullData         *pull_data,
-                          const char         *csum,
-                          OstreeObjectType    objtype,
-                          guint               recursion_depth,
-                          GCancellable       *cancellable,
-                          GError            **error)
+static void
+queue_scan_one_metadata_object (OtPullData         *pull_data,
+                                const char         *csum,
+                                OstreeObjectType    objtype,
+                                guint               recursion_depth)
 {
   guchar buf[32];
   ostree_checksum_inplace_to_bytes (csum, buf);
-  
-  return scan_one_metadata_object_c (pull_data, buf, objtype,
-                                     recursion_depth,
-                                     cancellable, error);
+  queue_scan_one_metadata_object_c (pull_data, buf, objtype, recursion_depth);
+}
+
+static void
+queue_scan_one_metadata_object_c (OtPullData         *pull_data,
+                                  const guchar         *csum,
+                                  OstreeObjectType    objtype,
+                                  guint               recursion_depth)
+{
+  ScanObjectQueueData *scan_data = g_new0 (ScanObjectQueueData, 1);
+
+  memcpy (scan_data->csum, csum, sizeof (scan_data->csum));
+  scan_data->objtype = objtype;
+  scan_data->recursion_depth = recursion_depth;
+
+  g_queue_push_tail (&pull_data->scan_object_queue, scan_data);
+  ensure_idle_queued (pull_data);
 }
 
 static gboolean
@@ -1784,6 +1829,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   pull_data->requested_metadata = g_hash_table_new_full (g_str_hash, g_str_equal,
                                                          (GDestroyNotify)g_free, NULL);
   pull_data->dir = g_strdup (dir_to_pull);
+  g_queue_init (&pull_data->scan_object_queue);
 
   pull_data->start_time = g_get_monotonic_time ();
 
@@ -2183,9 +2229,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   while (g_hash_table_iter_next (&hash_iter, &key, &value))
     {
       const char *commit = value;
-      if (!scan_one_metadata_object (pull_data, commit, OSTREE_OBJECT_TYPE_COMMIT,
-                                     0, pull_data->cancellable, error))
-        goto out;
+      queue_scan_one_metadata_object (pull_data, commit, OSTREE_OBJECT_TYPE_COMMIT, 0);
     }
 
   g_hash_table_iter_init (&hash_iter, requested_refs_to_fetch);
@@ -2212,9 +2256,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       if (!delta_superblock)
         {
           g_debug ("no delta superblock for %s-%s", from_revision ? from_revision : "empty", to_revision);
-          if (!scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT,
-                                         0, pull_data->cancellable, error))
-            goto out;
+          queue_scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT, 0);
         }
       else
         {
@@ -2239,6 +2281,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   /* Now await work completion */
   while (!pull_termination_condition (pull_data))
     g_main_context_iteration (pull_data->main_context, TRUE);
+
   if (pull_data->caught_error)
     goto out;
   
@@ -2367,6 +2410,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   g_clear_pointer (&pull_data->summary_deltas_checksums, (GDestroyNotify) g_hash_table_unref);
   g_clear_pointer (&pull_data->requested_content, (GDestroyNotify) g_hash_table_unref);
   g_clear_pointer (&pull_data->requested_metadata, (GDestroyNotify) g_hash_table_unref);
+  g_clear_pointer (&pull_data->idle_src, (GDestroyNotify) g_source_destroy);
   g_clear_pointer (&remote_config, (GDestroyNotify) g_key_file_unref);
   return ret;
 }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1928,10 +1928,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     }
   else
     {
-      g_autofree char *metalink_data = NULL;
+      g_autoptr(GBytes) summary_bytes = NULL;
       SoupURI *metalink_uri = soup_uri_new (metalink_url_str);
       SoupURI *target_uri = NULL;
-      gs_fd_close int fd = -1;
       
       if (!metalink_uri)
         {
@@ -1947,7 +1946,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       if (! _ostree_metalink_request_sync (metalink,
                                            pull_data->loop,
                                            &target_uri,
-                                           &metalink_data,
+                                           &summary_bytes,
                                            &pull_data->fetching_sync_uri,
                                            cancellable,
                                            error))
@@ -1959,16 +1958,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         soup_uri_set_path (pull_data->base_uri, repo_base);
       }
 
-      fd = openat (pull_data->tmpdir_dfd, metalink_data, O_RDONLY | O_CLOEXEC);
-      if (fd == -1)
-        {
-          gs_set_error_from_errno (error, errno);
-          goto out;
-        }
-
-      if (!ot_util_variant_map_fd (fd, 0, OSTREE_SUMMARY_GVARIANT_FORMAT, FALSE,
-                                   &pull_data->summary, error))
-        goto out;
+      pull_data->summary = g_variant_new_from_bytes (OSTREE_SUMMARY_GVARIANT_FORMAT,
+                                                     summary_bytes, FALSE);
     }
 
   if (!_ostree_repo_get_remote_list_option (self,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -45,7 +45,6 @@ typedef struct {
   OstreeRepo   *remote_repo_local;
 
   GMainContext    *main_context;
-  GMainLoop    *loop;
   GCancellable *cancellable;
   OstreeAsyncProgress *progress;
 
@@ -238,28 +237,9 @@ update_progress (gpointer user_data)
   return TRUE;
 }
 
-static void
-throw_async_error (OtPullData          *pull_data,
-                   GError              *error)
-{
-  if (error)
-    {
-      if (!pull_data->caught_error)
-        {
-          pull_data->caught_error = TRUE;
-          g_propagate_error (pull_data->async_error, error);
-          g_main_loop_quit (pull_data->loop);
-        }
-      else
-        {
-          g_error_free (error);
-        }
-    }
-}
-
-static void
-check_outstanding_requests_handle_error (OtPullData          *pull_data,
-                                         GError              *error)
+/* The core logic function for whether we should continue the main loop */
+static gboolean
+pull_termination_condition (OtPullData          *pull_data)
 {
   gboolean current_fetch_idle = (pull_data->n_outstanding_metadata_fetches == 0 &&
                                  pull_data->n_outstanding_content_fetches == 0 &&
@@ -269,30 +249,42 @@ check_outstanding_requests_handle_error (OtPullData          *pull_data,
                                  pull_data->n_outstanding_deltapart_write_requests == 0 );
   gboolean current_idle = current_fetch_idle && current_write_idle;
 
-  throw_async_error (pull_data, error);
+  if (pull_data->caught_error)
+    return TRUE;
 
   switch (pull_data->phase)
     {
     case OSTREE_PULL_PHASE_FETCHING_REFS:
       if (!pull_data->fetching_sync_uri)
-        g_main_loop_quit (pull_data->loop);
+        return TRUE;
       break;
     case OSTREE_PULL_PHASE_FETCHING_OBJECTS:
       if (current_idle && !pull_data->fetching_sync_uri)
         {
           g_debug ("pull: idle, exiting mainloop");
-          
-          g_main_loop_quit (pull_data->loop);
+          return TRUE;
         }
       break;
     }
+  return FALSE;
 }
 
-static gboolean
-idle_check_outstanding_requests (gpointer user_data)
+static void
+check_outstanding_requests_handle_error (OtPullData          *pull_data,
+                                         GError              *error)
 {
-  check_outstanding_requests_handle_error (user_data, NULL);
-  return FALSE;
+  if (error)
+    {
+      if (!pull_data->caught_error)
+        {
+          pull_data->caught_error = TRUE;
+          g_propagate_error (pull_data->async_error, error);
+        }
+      else
+        {
+          g_error_free (error);
+        }
+    }
 }
 
 typedef struct {
@@ -316,7 +308,6 @@ fetch_uri_contents_membuf_sync (OtPullData    *pull_data,
                                                add_nul,
                                                allow_noent,
                                                out_contents,
-                                               pull_data->loop,
                                                OSTREE_MAX_METADATA_SIZE,
                                                cancellable,
                                                error);
@@ -1748,7 +1739,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   const char *dir_to_pull = NULL;
   char **refs_to_fetch = NULL;
   GSource *update_timeout = NULL;
-  GSource *idle_src;
   gboolean disable_static_deltas = FALSE;
 
   if (options)
@@ -1773,7 +1763,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
   pull_data->async_error = error;
   pull_data->main_context = g_main_context_ref_thread_default ();
-  pull_data->loop = g_main_loop_new (pull_data->main_context, FALSE);
   pull_data->flags = flags;
 
   pull_data->repo = self;
@@ -1944,7 +1933,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       soup_uri_free (metalink_uri);
 
       if (! _ostree_metalink_request_sync (metalink,
-                                           pull_data->loop,
                                            &target_uri,
                                            &summary_bytes,
                                            &pull_data->fetching_sync_uri,
@@ -2177,6 +2165,14 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
 
   pull_data->phase = OSTREE_PULL_PHASE_FETCHING_OBJECTS;
 
+  /* Now discard the previous fetcher, as it was bound to a temporary main context
+   * for synchronous requests.
+   */
+  g_clear_object (&pull_data->fetcher);
+  pull_data->fetcher = _ostree_repo_remote_new_fetcher (self, remote_name_or_baseurl, error);
+  if (pull_data->fetcher == NULL)
+    goto out;
+
   if (!ostree_repo_prepare_transaction (pull_data->repo, &pull_data->transaction_resuming,
                                         cancellable, error))
     goto out;
@@ -2231,22 +2227,18 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         }
     }
 
-  idle_src = g_idle_source_new ();
-  g_source_set_callback (idle_src, idle_check_outstanding_requests, pull_data, NULL);
-  g_source_attach (idle_src, pull_data->main_context);
-  g_source_unref (idle_src);
-
   if (pull_data->progress)
     {
       update_timeout = g_timeout_source_new_seconds (1);
       g_source_set_priority (update_timeout, G_PRIORITY_HIGH);
       g_source_set_callback (update_timeout, update_progress, pull_data, NULL);
-      g_source_attach (update_timeout, g_main_loop_get_context (pull_data->loop));
+      g_source_attach (update_timeout, pull_data->main_context);
       g_source_unref (update_timeout);
     }
 
   /* Now await work completion */
-  g_main_loop_run (pull_data->loop);
+  while (!pull_termination_condition (pull_data))
+    g_main_context_iteration (pull_data->main_context, TRUE);
   if (pull_data->caught_error)
     goto out;
   
@@ -2359,8 +2351,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     g_source_destroy (idle_src);
   if (update_timeout)
     g_source_destroy (update_timeout);
-  if (pull_data->loop)
-    g_main_loop_unref (pull_data->loop);
   g_strfreev (configured_branches);
   g_clear_object (&pull_data->fetcher);
   g_clear_object (&pull_data->remote_repo_local);

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2330,8 +2330,6 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     
   ostree_repo_abort_transaction (pull_data->repo, cancellable, NULL);
   g_main_context_unref (pull_data->main_context);
-  if (idle_src)
-    g_source_destroy (idle_src);
   if (update_timeout)
     g_source_destroy (update_timeout);
   g_strfreev (configured_branches);


### PR DESCRIPTION
Bring a bunch of patches from upstream to fix timeout on pull. The key change here is https://github.com/endlessm/ostree/commit/c37341d717b8d703fc00b931a82240d6beca23eb, which depends directly on https://github.com/endlessm/ostree/commit/18c4ce69b7b8f57492524e5d85f48bf733b0f030. The upstream version of @magcius's change at https://github.com/endlessm/ostree/commit/b8dfbc84a760a2fd4ed524485d6afb3f6e66dea6 also replaces the version we had previously.

The other patches here are brought in to avoid major merge conflicts and fix bugs.

[endlessm/eos-shell#5697]