### PR TITLE
Revert "Revert "Revert "Don't make the root immutable"""

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1867,13 +1867,9 @@ ostree_sysroot_deploy_tree (OstreeSysroot     *self,
                                       cancellable, error))
     goto out;
 
-  /* Disable so that the /endless symlink can be created on boot */
-  /*
   if (!ostree_sysroot_deployment_set_mutable (self, new_deployment, FALSE,
                                               cancellable, error))
     goto out;
-  */
-
 
   { ostree_cleanup_sepolicy_fscreatecon gpointer dummy = NULL;
 


### PR DESCRIPTION
This reverts commit 3c3a52793c09da29c02f36d67a953ed234a8726c.
Now that /.readahead has been moved to /var/.readahead, systemd's
readahead implementation should not be broken by an immutable
root.

[endlessm/eos-shell#5190]