### PR TITLE
tests: Explicitly link libreaddir-rand with libdl

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -136,7 +136,7 @@ endif
 test_ltlibraries = libreaddir-rand.la
 libreaddir_rand_la_SOURCES = tests/readdir-rand.c
 libreaddir_rand_la_CFLAGS = $(OT_INTERNAL_GIO_UNIX_CFLAGS)
-libreaddir_rand_la_LIBADD = $(OT_INTERNAL_GIO_UNIX_LIBS)
+libreaddir_rand_la_LIBADD = $(OT_INTERNAL_GIO_UNIX_LIBS) -ldl
 libreaddir_rand_la_LDFLAGS = -avoid-version
 if !ENABLE_INSTALLED_TESTS
 libreaddir_rand_la_LDFLAGS += -rpath $(abs_builddir)


### PR DESCRIPTION
Since libreaddir-rand uses dlsym, it should link with libdl. Without
this, you may get an undefined symbol error.

https://phabricator.endlessm.com/T11513