### PR TITLE
tests: Improve check for /proc/cmdline kargs

### DIFF
--- a/tests/test-admin-deploy-karg.sh
+++ b/tests/test-admin-deploy-karg.sh
@@ -43,10 +43,9 @@ assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'option
 echo "ok deploy with --karg, but same config"
 
 ${CMD_PREFIX} ostree admin deploy --karg-proc-cmdline --os=testos testos:testos/buildmaster/x86_64-runtime
-# Here we're asserting that the *host* system has a root= kernel
-# argument.  I think it's unlikely that anyone doesn't have one, but
-# if this is not true for you, please file a bug!
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*root=.'
+for arg in $(cat /proc/cmdline); do
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+done
 
 echo "ok deploy --karg-proc-cmdline"
 

--- a/tests/test-admin-instutil-set-kargs.sh
+++ b/tests/test-admin-instutil-set-kargs.sh
@@ -54,8 +54,7 @@ assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'option
 echo "ok instutil set-kargs --append"
 
 ${CMD_PREFIX} ostree admin instutil set-kargs --import-proc-cmdline
-# Here we're asserting that the *host* system has a root= kernel
-# argument.  I think it's unlikely that anyone doesn't have one, but
-# if this is not true for you, please file a bug!
-assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf 'options.*root=.'
+for arg in $(cat /proc/cmdline); do
+    assert_file_has_content sysroot/boot/loader/entries/ostree-testos-0.conf "options.*$arg"
+done
 echo "ok instutil set-kargs --import-proc-cmdline"


### PR DESCRIPTION
On some systems there may be no root= argument, so the tests for
appending /proc/cmdline arguments will fail. Instead, loop over each of
the arguments in the host's /proc/cmdline and test that they're in the
constructed config file. That will actually test if ostree added all of
the system's /proc/cmdline args correctly.

https://phabricator.endlessm.com/T11513