### PR TITLE
Don't restrict the size of the legacy .sizes2 file

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1435,7 +1435,7 @@ enqueue_one_object_request (OtPullData        *pull_data,
   expected_max_size_p = (fetchtype != OSTREE_FETCH_OBJECT_CORE) ? NULL : g_hash_table_lookup (pull_data->expected_commit_sizes, checksum);
   if (expected_max_size_p)
     expected_max_size = *expected_max_size_p;
-  else if (is_meta)
+  else if (is_meta && fetchtype != OSTREE_FETCH_OBJECT_COMPAT_SIZES)
     expected_max_size = OSTREE_MAX_METADATA_SIZE;
   else
     expected_max_size = 0;


### PR DESCRIPTION
The legacy object sizes format is not very space efficient,
causing it to easily exceed OSTREE_MAX_METADATA_SIZE.

To avoid bailing out, don't verify the size of that file.

This got missed on the last rebase. I hit this on the server when pulling old commits. @smspillaz could you review?