### PR TITLE
repo: Revert default timestamp from 1 back to 0

### DIFF
--- a/docs/manual/repo.md
+++ b/docs/manual/repo.md
@@ -58,10 +58,11 @@ comparing timestamps. For Git, the logical choice is to not mess with
 timestamps, because unnecessary rebuilding is better than a broken tree.
 However, OSTree has to hardlink files to check them out, and commits are assumed
 to be internally consistent with no build steps needed. For this reason, OSTree
-acts as though all timestamps are set to time_t 1, so that comparisons will be
-considered up-to-date. 1 is a better choice than 0 because some programs use 0
-as a special value; for example, GNU Tar warns of an "implausibly old time
-stamp" with 0.
+acts as though all timestamps are set to time_t 0, so that comparisons will be
+considered up-to-date.  Note that for a few releases, OSTree used 1 to fix
+warnings such as GNU Tar emitting "implausibly old time stamp" with 0; however,
+until we have a mechanism to transition cleanly to 1, for compatibilty OSTree
+is reverted to use zero again.
 
 # Repository types and locations
 

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -32,7 +32,7 @@ G_BEGIN_DECLS
 #define _OSTREE_SUMMARY_CACHE_DIR "summaries"
 #define _OSTREE_CACHE_DIR "cache"
 
-#define OSTREE_TIMESTAMP (1)
+#define OSTREE_TIMESTAMP (0)
 
 typedef enum {
   OSTREE_REPO_TEST_ERROR_PRE_COMMIT = (1 << 0)

--- a/tests/basic-test.sh
+++ b/tests/basic-test.sh
@@ -392,9 +392,9 @@ else
     $OSTREE checkout test2 test2-checkout
 fi
 stat '--format=%Y' test2-checkout/baz/cow > cow-mtime
-assert_file_has_content cow-mtime 1
+assert_file_has_content cow-mtime 0
 stat '--format=%Y' test2-checkout/baz/deeper > deeper-mtime
-assert_file_has_content deeper-mtime 1
+assert_file_has_content deeper-mtime 0
 echo "ok content mtime"
 
 cd ${test_tmpdir}


### PR DESCRIPTION
Quoting Dan Nicholson in

  <https://github.com/ostreedev/ostree/pull/330#issuecomment-245499099>

  mtime of 0 has been the semantics of ostree deployments from basically
  the beginning of the project. We (and others, see
  flatpak/flatpak@b5204c9) rely on that fact when generating trees.

  In particular, this affects caches that use the mtime of the
  associated file or directory to determine if the cache is valid. By
  arbitrarily changing the mtime of the files to something else, all
  the caches we setup in the build are now invalidated. Preseeding
  caches is really important to the user experience as it avoids
  having the user wait while they're regenerated on first run.

  Now, we could change our build infrastructure to preset all the
  mtimes to 1 to match this change, but what does that do for our
  existing users who are on an ostree that deploys with mtimes of 0?
  We could just revert this change at Endless (and the associated one
  in Flatpak), and that would be fine for our users. However, if we
  point non-Endless users to our apps, they'll have the great
  experience of waiting 10 seconds the first time they launch it while
  the fontconfig cache is rebuilt unnecessarily.

Closes: #495
Approved by: jlebon