### PR TITLE
Various fixes

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -486,6 +486,31 @@ out:
   return ret;
 }
 
+/**
+ * ostree_repo_get_commit_sizes
+ * @self: Self
+ * @rev: Commit checksum
+ * @new_archived: (out) (optional): number of archived bytes for the commit
+ *                missing from the repository, or %NULL
+ * @new_unpacked: (out) (optional): number of unpacked bytes for the commit
+ *                missing from the repository, or %NULL
+ * @new_files: (out) (optional): number of files for the commit missing from
+ *             the repository, or %NULL
+ * @archived: (out) (optional): number of archived bytes for the commit in the
+ *            repository, or %NULL
+ * @unpacked: (out) (optional): number of unpacked bytes for the commit in the
+ *            repository, or %NULL
+ * @files: (out) (optional): number of files for the commit in the repository,
+ *         or %NULL
+ * @cancellable: a #GCancellable
+ * @error: a #GError
+ *
+ * Reads the size data for the commit stored in the %ostree.sizes key in
+ * the commit metadata. If this data is not available, %FALSE is
+ * returned and @error is set to %G_IO_ERROR_NOT_FOUND.
+ *
+ * Returns: %TRUE on success, %FALSE on failure
+ */
 gboolean
 ostree_repo_get_commit_sizes (OstreeRepo *self,
                               const char *rev,

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -522,7 +522,11 @@ ostree_repo_get_commit_sizes (OstreeRepo *self,
 
   sizes = g_variant_lookup_value (metadata, "ostree.sizes", G_VARIANT_TYPE("aay"));
   if (!sizes)
-    goto out; /* No size data is available */
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                   "No metadata key ostree.sizes in commit %s", rev);
+      goto out;
+    }
 
   g_variant_iter_init (&obj_iter, sizes);
   while ((object = g_variant_iter_next_value (&obj_iter)))

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3235,9 +3235,10 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
  * @self: Self
  * @name: name of a remote
  * @options: (nullable): A GVariant a{sv} with an extensible set of flags
- * @out_summary: (nullable): return location for raw summary data, or %NULL
- * @out_signatures: (nullable): return location for raw summary signature
- *                              data, or %NULL
+ * @out_summary: (out) (optional): return location for raw summary data, or
+ *               %NULL
+ * @out_signatures: (out) (optional): return location for raw summary
+ *                  signature data, or %NULL
  * @cancellable: a #GCancellable
  * @error: a #GError
  *

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1718,9 +1718,10 @@ out:
  * ostree_repo_remote_fetch_summary:
  * @self: Self
  * @name: name of a remote
- * @out_summary: (nullable): return location for raw summary data, or %NULL
- * @out_signatures: (nullable): return location for raw summary signature
- *                                data, or %NULL
+ * @out_summary: (out) (optional): return location for raw summary data, or
+ *               %NULL
+ * @out_signatures: (out) (optional): return location for raw summary
+ *                  signature data, or %NULL
  * @cancellable: a #GCancellable
  * @error: a #GError
  *

--- a/src/ostree/ot-builtin-size-summary.c
+++ b/src/ostree/ot-builtin-size-summary.c
@@ -30,6 +30,7 @@
 gboolean
 ostree_builtin_size_summary (int argc, char **argv, GCancellable *cancellable, GError **error)
 {
+  gboolean ret = FALSE;
   GOptionContext *context;
   OstreeRepo *repo;
   gsize entries = 0;
@@ -98,26 +99,27 @@ ostree_builtin_size_summary (int argc, char **argv, GCancellable *cancellable, G
       goto out;
     }
 
-  if (ostree_repo_get_commit_sizes (repo, revision,
-                                    &new_archived,
-                                    &new_unpacked,
-                                    &fetch_needed,
-                                    &archived, &unpacked,
-                                    &entries,
-                                    cancellable, error))
-    {
-      g_print ("Summary for refspec %s:\n"
-               "  files: %" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT " entries\n"
-               "  archived: %" G_GINT64_FORMAT "/%" G_GINT64_FORMAT "\n"
-               "  unpacked: %" G_GINT64_FORMAT "/%" G_GINT64_FORMAT "\n",
-               refspec,
-               entries - fetch_needed, entries,
-               archived - new_archived, archived,
-               unpacked - new_unpacked, unpacked);
-    }
+  if (!ostree_repo_get_commit_sizes (repo, revision,
+                                     &new_archived,
+                                     &new_unpacked,
+                                     &fetch_needed,
+                                     &archived, &unpacked,
+                                     &entries,
+                                     cancellable, error))
+    goto out;
 
+  g_print ("Summary for refspec %s:\n"
+           "  files: %" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT " entries\n"
+           "  archived: %" G_GINT64_FORMAT "/%" G_GINT64_FORMAT "\n"
+           "  unpacked: %" G_GINT64_FORMAT "/%" G_GINT64_FORMAT "\n",
+           refspec,
+           entries - fetch_needed, entries,
+           archived - new_archived, archived,
+           unpacked - new_unpacked, unpacked);
+
+  ret = TRUE;
  out:
   g_option_context_free (context);
 
-  return entries != 0;
+  return ret;
 }


### PR DESCRIPTION
A few fixes I found while working some ostree scripts for the image builder. The first commit got in upstream, and I'd like it here so I can actually read the remote summary data from python. The next 2 fix our non-upstreamed size summary to actually work correctly when the sizes information is not there. The last annotates the function so I can get commit sizes out from python.