### PR TITLE
Use dh_auto_test for testing

### DIFF
--- a/debian/test.sh
+++ b/debian/test.sh
@@ -7,7 +7,7 @@ export VERBOSE=1
 try_tests=5
 
 failed=0
-make check || failed=1
+dh_auto_test || failed=1
 
 if [ "$failed" -gt 0 ]; then
     [ "$failed" -eq 0 ] || echo "Test failed! Checking how reproducible it is..."


### PR DESCRIPTION
It should be clever enough to call make check, but it also respects
the DEB_BUILD_OPTIONS environment variable, so I can skip the tests
when doing scratch builds on my computer.