### PR TITLE
Don't remove ostree-boot files

### DIFF
--- a/debian/ostree.install
+++ b/debian/ostree.install
@@ -1,5 +1,11 @@
+etc/dracut.conf.d/ostree.conf
 etc/ostree
+lib/systemd/system/ostree*.service
+lib/systemd/system-generators/ostree-system-generator
 usr/bin/ostree
 usr/bin/rofiles-fuse
+usr/lib/dracut/modules.d/98ostree		
+usr/lib/ostree/ostree-prepare-root		
+usr/lib/ostree/ostree-remount
 usr/share/man
 usr/share/ostree/trusted.gpg.d

--- a/debian/ostree.maintscript
+++ b/debian/ostree.maintscript
@@ -1,2 +1,0 @@
-rm_conffile /etc/dracut.conf.d/ostree.conf 2017.3-2~ ostree
-rm_conffile /etc/grub.d/15_ostree 2017.3-2~ ostree

--- a/debian/rules
+++ b/debian/rules
@@ -46,18 +46,8 @@ override_dh_install:
 	rm -f debian/tmp/usr/lib/*/*.la
 	rm -f debian/tmp/usr/lib/installed-tests/libostree/*.la
 	:
-	# FIXME: when someone documents how to test these (#824649) they
-	# should be installed in a new ostree-boot package: see
-	# debian/ostree-boot.* and https://bugs.debian.org/824650
-	rm -f debian/tmp/etc/dracut.conf.d/ostree.conf
 	rm -f debian/tmp/etc/grub.d/15_ostree
-	rm -f debian/tmp/lib/systemd/system-generators/ostree-system-generator
-	rm -f debian/tmp/lib/systemd/system/ostree-prepare-root.service
-	rm -f debian/tmp/lib/systemd/system/ostree-remount.service
-	rm -fr debian/tmp/usr/lib/dracut/modules.d/98ostree/
 	rm -f debian/tmp/usr/lib/libostree/grub2-15_ostree
-	rm -f debian/tmp/usr/lib/ostree/ostree-prepare-root
-	rm -f debian/tmp/usr/lib/ostree/ostree-remount
 	:
 	dh_install --fail-missing
 


### PR DESCRIPTION
These files now belong to the ostree-boot package but,
since it'd require considerable effort in updating core
packages.

https://phabricator.endlessm.com/T17204