### PR TITLE
tests: Fix compat-files test

### DIFF
--- a/tests/test-compat-files.sh
+++ b/tests/test-compat-files.sh
@@ -17,9 +17,9 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-set -e
+set -euo pipefail
 
-if ! ${CMD_PREFIX} ostree --version | grep -q -e '\+gpgme'; then
+if ! ${CMD_PREFIX} ostree --version | grep -q -e 'gpgme'; then
     exit 77
 fi
 


### PR DESCRIPTION
Nowadays, 'ostree --version' prints the gpgme
feature prefixed with a - rather than a +.

This should be squashed to 9234affcf in a future
rebase.

https://phabricator.endlessm.com/T17204