### PR TITLE
Make 2017.6 work

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1698,19 +1698,10 @@ process_one_static_delta_fallback (OtPullData   *pull_data,
       /* The delta compiler never did this, there's no reason to support it */
       if (OSTREE_OBJECT_TYPE_IS_META (objtype))
         {
-          if (!g_hash_table_lookup (pull_data->requested_metadata, checksum))
-            {
-              FetchObjectType fetchtype;
-              g_hash_table_add (pull_data->requested_metadata, checksum);
-
-              if (objtype == OSTREE_OBJECT_TYPE_COMMIT)
-                fetchtype = OSTREE_FETCH_OBJECT_DETACHED_METADATA;
-              else
-                fetchtype = OSTREE_FETCH_OBJECT_CORE;
-              enqueue_one_object_request (pull_data, checksum, objtype, NULL,
-                                          fetchtype, FALSE);
-              checksum = NULL;  /* Transfer ownership */
-            }
+          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "Found metadata object as fallback: %s.%s", checksum,
+                       ostree_object_type_to_string (objtype));
+          goto out;
         }
       else
         {

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -899,7 +899,6 @@ meta_fetch_on_complete (GObject           *object,
   FetchObjectData *fetch_data = user_data;
   OtPullData *pull_data = fetch_data->pull_data;
   g_autoptr(GVariant) metadata = NULL;
-  GMappedFile *signature_file = NULL;
   g_autofree char *temp_path = NULL;
   const char *checksum;
   g_autofree char *checksum_obj = NULL;
@@ -1019,6 +1018,7 @@ meta_fetch_on_complete (GObject           *object,
     }
   else if (fetch_data->type == OSTREE_FETCH_OBJECT_COMPAT_SIGNATURE)
     {
+      g_autoptr(GMappedFile) signature_file = NULL;
       g_autoptr(GBytes) signature = NULL;
 
       signature_file = g_mapped_file_new_from_fd (fd, FALSE, error);
@@ -1070,8 +1070,6 @@ meta_fetch_on_complete (GObject           *object,
   pull_data->n_outstanding_metadata_fetches--;
   pull_data->n_fetched_metadata++;
   check_outstanding_requests_handle_error (pull_data, &local_error);
-  if (signature_file)
-    g_mapped_file_unref (signature_file);
   if (free_fetch_data)
     fetch_object_data_free (fetch_data);
 }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -948,7 +948,8 @@ meta_fetch_on_complete (GObject           *object,
               if (next == OSTREE_FETCH_OBJECT_CORE && fetch_data->object_is_stored)
                 queue_scan_one_metadata_object (pull_data, checksum, objtype, fetch_data->path, 0);
               else
-                enqueue_one_object_request (pull_data, checksum, objtype, fetch_data->path, next, FALSE);
+                enqueue_one_object_request (pull_data, checksum, objtype, fetch_data->path, next,
+                                            fetch_data->object_is_stored);
             }
 
           /* When traversing parents, do not fail on a missing commit.
@@ -997,7 +998,8 @@ meta_fetch_on_complete (GObject           *object,
 
       /* Request compat sizes */
       enqueue_one_object_request (pull_data, checksum, objtype, fetch_data->path,
-                                  OSTREE_FETCH_OBJECT_COMPAT_SIZES, FALSE);
+                                  OSTREE_FETCH_OBJECT_COMPAT_SIZES,
+                                  fetch_data->object_is_stored);
     }
   else if (fetch_data->type == OSTREE_FETCH_OBJECT_COMPAT_SIZES)
     {
@@ -1014,7 +1016,8 @@ meta_fetch_on_complete (GObject           *object,
 
       /* Request compat signature */
       enqueue_one_object_request (pull_data, checksum, objtype, fetch_data->path,
-                                  OSTREE_FETCH_OBJECT_COMPAT_SIGNATURE, FALSE);
+                                  OSTREE_FETCH_OBJECT_COMPAT_SIGNATURE,
+                                  fetch_data->object_is_stored);
     }
   else if (fetch_data->type == OSTREE_FETCH_OBJECT_COMPAT_SIGNATURE)
     {

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1470,10 +1470,6 @@ scan_one_metadata_object_c (OtPullData         *pull_data,
                                     OSTREE_FETCH_OBJECT_DETACHED_METADATA, TRUE);
       else
         {
-          /* For commits, always refetch detached metadata. */
-          enqueue_one_object_request (pull_data, tmp_checksum, objtype, path,
-                                      OSTREE_FETCH_OBJECT_DETACHED_METADATA, TRUE);
-
           if (!scan_commit_object (pull_data, tmp_checksum, recursion_depth,
                                    pull_data->cancellable, error))
             goto out;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1560,6 +1560,12 @@ start_fetch (OtPullData *pull_data,
   is_meta = OSTREE_OBJECT_TYPE_IS_META (objtype);
   fetchtype = fetch->type;
 
+  g_debug ("starting fetch of %s.%s%s%s%s", expected_checksum,
+           ostree_object_type_to_string (objtype),
+           (fetchtype == OSTREE_FETCH_OBJECT_DETACHED_METADATA) ? " (detached)" : "",
+           (fetchtype == OSTREE_FETCH_OBJECT_COMPAT_SIZES) ? " (compat sizes)" : "",
+           (fetchtype == OSTREE_FETCH_OBJECT_COMPAT_SIGNATURE) ? " (compat signature)" : "");
+
   is_meta = OSTREE_OBJECT_TYPE_IS_META (objtype);
   if (is_meta)
     pull_data->n_outstanding_metadata_fetches++;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -964,7 +964,7 @@ meta_fetch_on_complete (GObject           *object,
               if (pull_data->has_tombstone_commits)
                 {
                   enqueue_one_object_request (pull_data, checksum, OSTREE_OBJECT_TYPE_TOMBSTONE_COMMIT,
-                                              fetch_data->path, FALSE, FALSE);
+                                              fetch_data->path, OSTREE_FETCH_OBJECT_CORE, FALSE);
                 }
             }
         }

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -305,13 +305,16 @@ ${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo summary -u
 csum=$(${CMD_PREFIX} ostree --repo=ostree-srv/gnomerepo rev-parse main)
 objpath=objects/${csum::2}/${csum:2}.commitmeta
 remotesig=ostree-srv/gnomerepo/$objpath
+remotesig_compat=${remotesig%.commitmeta}.sig
 localsig=repo/$objpath
 mv $remotesig $remotesig.bak
+mv $remotesig_compat $remotesig_compat.bak
 if ${CMD_PREFIX} ostree --repo=repo --depth=0 pull origin main; then
     assert_not_reached "pull with gpg-verify unexpectedly succeeded?"
 fi
 # ok now check that we can pull correctly
 mv $remotesig.bak $remotesig
+mv $remotesig_compat.bak $remotesig_compat
 ${CMD_PREFIX} ostree --repo=repo pull origin main
 echo "ok pull signed commit"
 rm $localsig

--- a/tests/test-compat-files.sh
+++ b/tests/test-compat-files.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-if ! ${CMD_PREFIX} ostree --version | grep -q -e 'gpgme'; then
+if ! ostree --version | grep -q -e 'gpgme'; then
     exit 77
 fi
 


### PR DESCRIPTION
This is almost entirely making fb0a4b7 work after a8fd37b. Some issues were because the rebasing of the patch wasn't applied quite right, others were things that a8fd37b changed in the pull behavior that needed to be handled, and one was a bug that turned into an error.

There are a couple other test fixes needed at the beginning of the series. After this, the test suite fully passes reliably for me.

https://phabricator.endlessm.com/T17204