### PR TITLE
debian: Drop <!nodoc> profile from ostree.install due to lack of tooling

### DIFF
--- a/debian/ostree.install
+++ b/debian/ostree.install
@@ -9,5 +9,5 @@ usr/bin/rofiles-fuse
 usr/lib/dracut/modules.d/98ostree		
 usr/lib/ostree/ostree-prepare-root		
 usr/lib/ostree/ostree-remount
-usr/share/man <!nodoc>
+usr/share/man
 usr/share/ostree/trusted.gpg.d


### PR DESCRIPTION
Our toolchain doesn’t currently support this profile, which results in
the man pages getting installed in `/<!nodoc>`, which is suboptimal.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T18832