### PR TITLE
debian: Update to 2017.10 and enable --enable-experimental-api flag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+ostree (2017.10-1endless1) unstable; urgency=medium
+
+  * New upstream release
+    - Update symbols file
+    - Add Build-Depends-Indep for docs as per upstream packaging
+  * Enable --enable-experimental-api configure flag — this will enable P2P
+    functionality in libostree
+
+ -- Philip Withnall <withnall@endlessm.com>  Wed, 22 Aug 2017 12:08:00 +0100
+
 ostree (2017.7-1endless1) unstable; urgency=medium
 
   * Resync Debian packaging changes

--- a/debian/control
+++ b/debian/control
@@ -41,6 +41,8 @@ Build-Depends:
  python-yaml <!nocheck>,
  xsltproc <!nodoc>,
  zlib1g-dev,
+Build-Depends-Indep:
+ libglib2.0-doc,
 Standards-Version: 4.0.0
 Homepage: https://github.com/ostreedev/ostree/
 Vcs-Git: https://anonscm.debian.org/git/collab-maint/ostree.git

--- a/debian/libostree-1-1.symbols
+++ b/debian/libostree-1-1.symbols
@@ -7,12 +7,18 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  LIBOSTREE_2016.7@LIBOSTREE_2016.7 2016.7
  LIBOSTREE_2016.8@LIBOSTREE_2016.8 2016.8
  LIBOSTREE_2016.14@LIBOSTREE_2016.14 2016.14
+ LIBOSTREE_2017.10@LIBOSTREE_2017.10 2017.10
  LIBOSTREE_2017.1@LIBOSTREE_2017.1 2017.1
  LIBOSTREE_2017.2@LIBOSTREE_2017.2 2017.2
  LIBOSTREE_2017.3@LIBOSTREE_2017.3 2017.3
  LIBOSTREE_2017.4@LIBOSTREE_2017.4 2017.4
  LIBOSTREE_2017.6@LIBOSTREE_2017.6 2017.6
+ LIBOSTREE_2017.6_EXPERIMENTAL@LIBOSTREE_2017.6_EXPERIMENTAL 2017.7
  LIBOSTREE_2017.7@LIBOSTREE_2017.7 2017.7
+ LIBOSTREE_2017.7_EXPERIMENTAL@LIBOSTREE_2017.7_EXPERIMENTAL 2017.7
+ LIBOSTREE_2017.8@LIBOSTREE_2017.8 2017.8
+ LIBOSTREE_2017.8_EXPERIMENTAL@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ LIBOSTREE_2017.9@LIBOSTREE_2017.9 2017.9
  ostree_async_progress_finish@LIBOSTREE_2016.3 2016.4
  ostree_async_progress_get@LIBOSTREE_2017.6 2017.6
  ostree_async_progress_get_status@LIBOSTREE_2016.3 2016.4
@@ -59,6 +65,14 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_checksum_to_bytes_v@LIBOSTREE_2016.3 2016.4
  ostree_cmd__private__@LIBOSTREE_2016.3 2016.4
  ostree_cmp_checksum_bytes@LIBOSTREE_2016.3 2016.4
+ ostree_collection_ref_dup@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_collection_ref_dupv@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_collection_ref_equal@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_collection_ref_free@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_collection_ref_freev@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_collection_ref_get_type@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_collection_ref_hash@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_collection_ref_new@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
  ostree_commit_get_parent@LIBOSTREE_2016.3 2016.4
  ostree_commit_get_timestamp@LIBOSTREE_2016.3 2016.4
  ostree_content_file_parse@LIBOSTREE_2016.3 2016.4
@@ -92,6 +106,7 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_diff_item_unref@LIBOSTREE_2016.3 2016.4
  ostree_diff_print@LIBOSTREE_2016.3 2016.4
  ostree_fetcher_config_flags_get_type@LIBOSTREE_2016.3 2016.4
+ ostree_gpg_error_quark@LIBOSTREE_2017.10 2017.10
  ostree_gpg_verify_result_count_all@LIBOSTREE_2016.3 2016.4
  ostree_gpg_verify_result_count_valid@LIBOSTREE_2016.3 2016.4
  ostree_gpg_verify_result_describe@LIBOSTREE_2016.3 2016.4
@@ -126,6 +141,9 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_raw_file_to_archive_z2_stream@LIBOSTREE_2016.6 2016.6
  ostree_raw_file_to_archive_z2_stream_with_options@LIBOSTREE_2017.3 2017.3
  ostree_raw_file_to_content_stream@LIBOSTREE_2016.3 2016.4
+ ostree_remote_ref@LIBOSTREE_2017.6_EXPERIMENTAL 2017.8
+ ostree_remote_unref@LIBOSTREE_2017.6_EXPERIMENTAL 2017.8
+ ostree_remote_get_name@LIBOSTREE_2017.7_EXPERIMENTAL 2017.8
  ostree_repo_abort_transaction@LIBOSTREE_2016.3 2016.4
  ostree_repo_add_gpg_signature_summary@LIBOSTREE_2016.3 2016.4
  ostree_repo_append_gpg_signature@LIBOSTREE_2016.3 2016.4
@@ -150,6 +168,7 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_repo_commit_traverse_iter_next@LIBOSTREE_2016.3 2016.4
  ostree_repo_copy_config@LIBOSTREE_2016.3 2016.4
  ostree_repo_create@LIBOSTREE_2016.3 2016.4
+ ostree_repo_create_at@LIBOSTREE_2017.10 2017.10
  ostree_repo_delete_compat_signature@LIBOSTREE_2016.3 2016.3
  ostree_repo_delete_object@LIBOSTREE_2016.3 2016.4
  ostree_repo_devino_cache_get_type@LIBOSTREE_2016.3 2016.4
@@ -170,6 +189,28 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_repo_file_tree_get_metadata_checksum@LIBOSTREE_2016.3 2016.4
  ostree_repo_file_tree_query_child@LIBOSTREE_2016.3 2016.4
  ostree_repo_file_tree_set_metadata@LIBOSTREE_2016.3 2016.4
+ ostree_repo_find_remotes_async@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_find_remotes_finish@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_avahi_get_type@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_avahi_new@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_avahi_start@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_avahi_stop@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_config_get_type@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_config_new@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_get_type@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_mount_get_type@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_mount_new@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_resolve_async@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_resolve_all_async@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_resolve_all_finish@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_resolve_finish@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_result_compare@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_result_dup@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_result_free@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_result_freev@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_result_get_type@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_finder_result_new@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_get_collection_id@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
  ostree_repo_get_commit_sizes@LIBOSTREE_2016.3 2016.3
  ostree_repo_get_config@LIBOSTREE_2016.3 2016.4
  ostree_repo_get_dfd@LIBOSTREE_2016.4 2016.4
@@ -188,6 +229,7 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_repo_import_object_from_with_trust@LIBOSTREE_2016.5 2016.5
  ostree_repo_is_system@LIBOSTREE_2016.3 2016.4
  ostree_repo_is_writable@LIBOSTREE_2016.3 2016.4
+ ostree_repo_list_collection_refs@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
  ostree_repo_list_commit_objects_starting_with@LIBOSTREE_2016.3 2016.4
  ostree_repo_list_objects@LIBOSTREE_2016.3 2016.4
  ostree_repo_list_refs@LIBOSTREE_2016.3 2016.4
@@ -203,12 +245,15 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_repo_new_default@LIBOSTREE_2016.3 2016.4
  ostree_repo_new_for_sysroot_path@LIBOSTREE_2016.3 2016.4
  ostree_repo_open@LIBOSTREE_2016.3 2016.4
+ ostree_repo_open_at@LIBOSTREE_2017.10 2017.10
  ostree_repo_prepare_transaction@LIBOSTREE_2016.3 2016.4
  ostree_repo_prune@LIBOSTREE_2016.3 2016.4
  ostree_repo_prune_from_reachable@LIBOSTREE_2017.1 2017.1
  ostree_repo_prune_static_deltas@LIBOSTREE_2016.3 2016.4
  ostree_repo_pull@LIBOSTREE_2016.3 2016.4
  ostree_repo_pull_default_console_progress_changed@LIBOSTREE_2016.3 2016.4
+ ostree_repo_pull_from_remotes_async@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_pull_from_remotes_finish@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
  ostree_repo_pull_one_dir@LIBOSTREE_2016.3 2016.4
  ostree_repo_pull_with_options@LIBOSTREE_2016.3 2016.4
  ostree_repo_query_object_storage_size@LIBOSTREE_2016.3 2016.4
@@ -226,17 +271,23 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_repo_remote_get_url@LIBOSTREE_2016.3 2016.4
  ostree_repo_remote_gpg_import@LIBOSTREE_2016.3 2016.4
  ostree_repo_remote_list@LIBOSTREE_2016.3 2016.4
+ ostree_repo_remote_list_collection_refs@LIBOSTREE_2017.8_EXPERIMENTAL 2017.10
  ostree_repo_remote_list_refs@LIBOSTREE_2016.3 2016.4
+ ostree_repo_resolve_keyring_for_collection@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
  ostree_repo_resolve_rev@LIBOSTREE_2016.3 2016.4
  ostree_repo_resolve_rev_ext@LIBOSTREE_2016.7 2016.7
  ostree_repo_scan_hardlinks@LIBOSTREE_2016.3 2016.4
+ ostree_repo_set_alias_ref_immediate@LIBOSTREE_2017.10 2017.10
  ostree_repo_set_cache_dir@LIBOSTREE_2016.5 2016.5
+ ostree_repo_set_collection_id@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_repo_set_collection_ref_immediate@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
  ostree_repo_set_disable_fsync@LIBOSTREE_2016.3 2016.4
  ostree_repo_set_ref_immediate@LIBOSTREE_2016.3 2016.4
  ostree_repo_sign_commit@LIBOSTREE_2016.3 2016.4
  ostree_repo_sign_delta@LIBOSTREE_2016.3 2016.4
  ostree_repo_static_delta_execute_offline@LIBOSTREE_2016.3 2016.4
  ostree_repo_static_delta_generate@LIBOSTREE_2016.3 2016.4
+ ostree_repo_transaction_set_collection_ref@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
  ostree_repo_transaction_set_ref@LIBOSTREE_2016.3 2016.4
  ostree_repo_transaction_set_refspec@LIBOSTREE_2016.3 2016.4
  ostree_repo_transaction_stats_get_type@LIBOSTREE_2016.3 2016.4
@@ -325,6 +376,8 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_sysroot_write_deployments_with_options@LIBOSTREE_2017.4 2017.4
  ostree_sysroot_write_origin_file@LIBOSTREE_2016.3 2016.4
  ostree_validate_checksum_string@LIBOSTREE_2016.3 2016.4
+ ostree_validate_collection_id@LIBOSTREE_2017.8_EXPERIMENTAL 2017.8
+ ostree_validate_remote_name@LIBOSTREE_2017.8 2017.8
  ostree_validate_rev@LIBOSTREE_2016.3 2016.4
  ostree_validate_structureof_checksum_string@LIBOSTREE_2016.3 2016.4
  ostree_validate_structureof_commit@LIBOSTREE_2016.3 2016.4

--- a/debian/ostree.install
+++ b/debian/ostree.install
@@ -9,5 +9,6 @@ usr/bin/rofiles-fuse
 usr/lib/dracut/modules.d/98ostree		
 usr/lib/ostree/ostree-prepare-root		
 usr/lib/ostree/ostree-remount
+usr/share/bash-completion/completions/ostree
 usr/share/man
 usr/share/ostree/trusted.gpg.d

--- a/debian/rules
+++ b/debian/rules
@@ -17,6 +17,7 @@ override_dh_autoreconf:
 	cp debian/dist/ostree-trivial-httpd.xml man/
 
 configure_options = \
+	--enable-experimental-api \
 	--enable-installed-tests \
 	--enable-trivial-httpd-cmdline \
 	--libexecdir='$${prefix}/lib' \
@@ -25,6 +26,7 @@ configure_options = \
 	--with-grub2-mkconfig-path=/usr/sbin/grub-mkconfig \
 	--with-systemdsystemgeneratordir=/lib/systemd/system-generators \
 	--with-systemdsystemunitdir=/lib/systemd/system \
+	BASH_COMPLETIONSDIR=/usr/share/bash-completion/completions \
 	$(NULL)
 
 ifeq (,$(filter nodoc,$(DEB_BUILD_PROFILES)))


### PR DESCRIPTION
 * New upstream release
   - Install bash-completion script
 * Enable --enable-experimental-api configure flag — this will enable P2P
   functionality in libostree

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T16919