### PR TITLE
Fix handling of /etc/ostree/remotes.d

### DIFF
--- a/Makefile-tests.am
+++ b/Makefile-tests.am
@@ -188,6 +188,7 @@ endif
 
 js_installed_tests = \
 	tests/test-core.js \
+	tests/test-remotes-config-dir.js \
 	tests/test-sizes.js \
 	tests/test-sysroot.js \
 	$(NULL)

--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -122,6 +122,27 @@ Boston, MA 02111-1307, USA.
         keep free. The default value is 3.</para></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>add-remotes-config-dir</varname></term>
+        <listitem>
+          <para>
+            Boolean value controlling whether new remotes will be added
+            in the remotes configuration directory. Defaults to
+            <literal>true</literal> for system ostree repositories. When
+            this is <literal>false</literal>, remotes will be added in
+            the repository's <filename>config</filename> file.
+          </para>
+          <para>
+            This only applies to repositories that use a remotes
+            configuration directory such as system ostree repositories,
+            which use <filename>/etc/ostree/remotes.d</filename>.
+            Non-system repositories do not use a remotes configuration
+            directory unless one is specified when the repository is
+            opened.
+          </para>
+        </listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -154,6 +154,7 @@ struct OstreeRepo {
   gboolean generate_sizes;
   guint64 tmp_expiry_seconds;
   gchar *collection_id;
+  gboolean add_remotes_config_dir; /* Add new remotes in remotes.d dir */
 
   OstreeRepo *parent_repo;
 };

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -957,11 +957,12 @@ impl_repo_remote_add (OstreeRepo     *self,
 
   remote = ostree_remote_new (name);
 
-  /* Only add repos in remotes.d for system repos since that was the
-   * legacy behavior and non-system repos would not expect it.
+  /* Only add repos in remotes.d if the repo option
+   * add-remotes-config-dir is true. This is the default for system
+   * repos.
    */
   g_autoptr(GFile) etc_ostree_remotes_d = get_remotes_d_dir (self, sysroot);
-  if (etc_ostree_remotes_d && ostree_repo_is_system (self))
+  if (etc_ostree_remotes_d && self->add_remotes_config_dir)
     {
       g_autoptr(GError) local_error = NULL;
 
@@ -2184,6 +2185,17 @@ reload_core_config (OstreeRepo          *self,
           return FALSE;
         }
     }
+
+  /* By default, only add remotes in a remotes config directory for
+   * system repos. This is to preserve legacy behavior for non-system
+   * repos that specify a remotes config dir (flatpak).
+   */
+  { gboolean is_system = ostree_repo_is_system (self);
+
+    if (!ot_keyfile_get_boolean_with_default (self->config, "core", "add-remotes-config-dir",
+                                              is_system, &self->add_remotes_config_dir, error))
+      return FALSE;
+  }
 
   return TRUE;
 }

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -957,8 +957,11 @@ impl_repo_remote_add (OstreeRepo     *self,
 
   remote = ostree_remote_new (name);
 
+  /* Only add repos in remotes.d for system repos since that was the
+   * legacy behavior and non-system repos would not expect it.
+   */
   g_autoptr(GFile) etc_ostree_remotes_d = get_remotes_d_dir (self, sysroot);
-  if (etc_ostree_remotes_d)
+  if (etc_ostree_remotes_d && ostree_repo_is_system (self))
     {
       g_autoptr(GError) local_error = NULL;
 
@@ -1994,10 +1997,6 @@ static GFile *
 get_remotes_d_dir (OstreeRepo          *self,
                    GFile               *sysroot)
 {
-  /* Support explicit override */
-  if (self->sysroot_dir != NULL && self->remotes_config_dir != NULL)
-    return g_file_resolve_relative_path (self->sysroot_dir, self->remotes_config_dir);
-
   g_autoptr(GFile) sysroot_owned = NULL;
   /* Very complicated sysroot logic; this bit breaks the otherwise mostly clean
    * layering between OstreeRepo and OstreeSysroot. First, If a sysroot was
@@ -2033,10 +2032,18 @@ get_remotes_d_dir (OstreeRepo          *self,
   if (sysroot == NULL && sysroot_ref == NULL)
     sysroot = self->sysroot_dir;
 
-  /* Did we find a sysroot? If not, NULL means use the repo config, otherwise
-   * return the path in /etc.
+  /* Was the config directory specified? If so, use that with the
+   * optional sysroot prepended. If not, return the path in /etc if the
+   * sysroot was found and NULL otherwise to use the repo config.
    */
-  if (sysroot == NULL)
+  if (self->remotes_config_dir != NULL)
+    {
+      if (sysroot == NULL)
+        return g_file_new_for_path (self->remotes_config_dir);
+      else
+        return g_file_resolve_relative_path (sysroot, self->remotes_config_dir);
+    }
+  else if (sysroot == NULL)
     return NULL;
   else
     return g_file_resolve_relative_path (sysroot, SYSCONF_REMOTES);

--- a/src/libostree/ostree-sysroot.c
+++ b/src/libostree/ostree-sysroot.c
@@ -772,6 +772,13 @@ ensure_repo (OstreeSysroot  *self,
    */
   g_weak_ref_init (&self->repo->sysroot, self);
   self->repo->sysroot_kind = OSTREE_REPO_SYSROOT_KIND_VIA_SYSROOT;
+
+  /* Reload the repo config in case any defaults depend on knowing if this is
+   * a system repo.
+   */
+  if (!ostree_repo_reload_config (self->repo, NULL, error))
+    return FALSE;
+
   return TRUE;
 }
 

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -250,6 +250,15 @@ assert_not_file_has_content sysroot/ostree/repo/config remote-test-nonphysical
 assert_file_has_content ${deployment}/etc/ostree/remotes.d/remote-test-nonphysical.conf testos-repo
 echo "ok remote add nonphysical sysroot"
 
+# Test that setting add-remotes-config-dir to false adds a remote in the
+# config file rather than the remotes config dir even though this is a
+# "system" repo.
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo config set core.add-remotes-config-dir false
+${CMD_PREFIX} ostree --sysroot=${deployment} remote add --set=gpg-verify=false remote-test-config-dir file://$(pwd)/testos-repo
+assert_not_has_file ${deployment}/etc/ostree/remotes.d/remote-test-config-dir.conf testos-repo
+assert_file_has_content sysroot/ostree/repo/config remote-test-config-dir
+echo "ok remote add nonphysical sysroot add-remotes-config-dir false"
+
 if env OSTREE_SYSROOT_DEBUG="${OSTREE_SYSROOT_DEBUG},test-fifreeze" \
        ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime 2>err.txt; then
     fatal "fifreeze-test exited successfully?"

--- a/tests/test-admin-deploy-grub2.sh
+++ b/tests/test-admin-deploy-grub2.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..19"
+echo "1..20"
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-syslinux.sh
+++ b/tests/test-admin-deploy-syslinux.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-echo "1..20"
+echo "1..21"
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-admin-deploy-uboot.sh
+++ b/tests/test-admin-deploy-uboot.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-echo "1..20"
+echo "1..21"
 
 . $(dirname $0)/libtest.sh
 

--- a/tests/test-remotes-config-dir.js
+++ b/tests/test-remotes-config-dir.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env gjs
+//
+// Copyright (C) 2013 Colin Walters <walters@verbum.org>
+// Copyright (C) 2017 Dan Nicholson <nicholson@endlessm.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+const GLib = imports.gi.GLib;
+const Gio = imports.gi.Gio;
+const OSTree = imports.gi.OSTree;
+
+function assertEquals(a, b) {
+    if (a != b)
+	throw new Error("assertion failed " + JSON.stringify(a) + " == " + JSON.stringify(b));
+}
+
+function assertNotEquals(a, b) {
+    if (a == b)
+	throw new Error("assertion failed " + JSON.stringify(a) + " != " + JSON.stringify(b));
+}
+
+print('1..3')
+
+let remotesDir = Gio.File.new_for_path('remotes.d');
+remotesDir.make_directory(null);
+
+let remoteConfig = GLib.KeyFile.new()
+remoteConfig.set_value('remote "foo"', 'url', 'http://foo')
+
+let remoteConfigFile = remotesDir.get_child('foo.conf')
+remoteConfig.save_to_file(remoteConfigFile.get_path())
+
+// Use the full Repo constructor to set remotes-config-dir
+let repoFile = Gio.File.new_for_path('repo');
+let repo = new OSTree.Repo({path: repoFile,
+                            remotes_config_dir: remotesDir.get_path()});
+repo.create(OSTree.RepoMode.ARCHIVE_Z2, null);
+repo.open(null);
+
+// See if the remotes.d remote exists
+let remotes = repo.remote_list()
+assertNotEquals(remotes.indexOf('foo'), -1);
+
+print("ok read-remotes-config-dir");
+
+// Adding a remote should not go in the remotes.d dir
+repo.remote_add('bar', 'http://bar', null, null);
+remotes = repo.remote_list()
+assertNotEquals(remotes.indexOf('bar'), -1);
+assertEquals(remotesDir.get_child('bar.conf').query_exists(null), false);
+
+print("ok add-not-in-remotes-config-dir");
+
+// Removing the remotes.d remote should delete the conf file
+repo.remote_delete('foo', null);
+remotes = repo.remote_list()
+assertEquals(remotes.indexOf('foo'), -1);
+assertEquals(remotesDir.get_child('foo.conf').query_exists(null), false);
+
+print("ok delete-in-remotes-config-dir");

--- a/tests/test-remotes-config-dir.js
+++ b/tests/test-remotes-config-dir.js
@@ -32,7 +32,7 @@ function assertNotEquals(a, b) {
 	throw new Error("assertion failed " + JSON.stringify(a) + " != " + JSON.stringify(b));
 }
 
-print('1..3')
+print('1..4')
 
 let remotesDir = Gio.File.new_for_path('remotes.d');
 remotesDir.make_directory(null);
@@ -56,7 +56,8 @@ assertNotEquals(remotes.indexOf('foo'), -1);
 
 print("ok read-remotes-config-dir");
 
-// Adding a remote should not go in the remotes.d dir
+// Adding a remote should not go in the remotes.d dir unless this is a
+// system repo or add-remotes-config-dir is set to true
 repo.remote_add('bar', 'http://bar', null, null);
 remotes = repo.remote_list()
 assertNotEquals(remotes.indexOf('bar'), -1);
@@ -71,3 +72,16 @@ assertEquals(remotes.indexOf('foo'), -1);
 assertEquals(remotesDir.get_child('foo.conf').query_exists(null), false);
 
 print("ok delete-in-remotes-config-dir");
+
+// Set add-remotes-config-dir to true and check that a remote gets added
+// in the config dir
+let repoConfig = repo.copy_config();
+repoConfig.set_boolean('core', 'add-remotes-config-dir', true);
+repo.write_config(repoConfig);
+repo.reload_config(null);
+repo.remote_add('baz', 'http://baz', null, null);
+remotes = repo.remote_list()
+assertNotEquals(remotes.indexOf('baz'), -1);
+assertEquals(remotesDir.get_child('baz.conf').query_exists(null), true);
+
+print("ok add-in-remotes-config-dir");


### PR DESCRIPTION
This is a backport of https://github.com/ostreedev/ostree/pull/1151 and https://github.com/ostreedev/ostree/pull/1155 that allows fixing how /etc/ostree/remotes.d is used when remotes are added. This was breaking 2 cases we care about at Endless:

1. Flatpak using system ostree repo
2. ostree-receive service specifying a remotes config dir for a non-system repo

https://phabricator.endlessm.com/T19077
https://phabricator.endlessm.com/T18830