### PR TITLE
Disable rofiles-fuse on ARM

### DIFF
--- a/debian/ostree.install
+++ b/debian/ostree.install
@@ -2,7 +2,7 @@
 
 etc/ostree
 usr/bin/ostree
-usr/bin/rofiles-fuse
+[!armhf] usr/bin/rofiles-fuse
 usr/share/bash-completion/completions/ostree
 usr/share/man <!nodoc>
 usr/share/ostree/trusted.gpg.d

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 # Some tests assert that we will see English strings
 export LC_ALL=C.UTF-8
+DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 
 %:
 	dh $@ --parallel --with=autoreconf,gir,systemd
@@ -29,6 +30,16 @@ configure_options += --enable-man
 else
 configure_options += --disable-gtk-doc
 configure_options += --disable-man
+endif
+
+# rofiles-fuse causes a kernel hang on the Xenial armhf kernel somewhere
+# in the splice system call. This is almost certainly a FUSE issue in
+# the kernel, but just disable it for now until it can be reliably
+# reproduced and fixed.
+#
+# https://phabricator.endlessm.com/T18830
+ifeq ($(DEB_HOST_ARCH),armhf)
+configure_options += --disable-rofiles-fuse
 endif
 
 override_dh_auto_configure:


### PR DESCRIPTION
Use of rofiles-fuse is causing a kernel hang on the Xenial armhf kernel.

  kernel: INFO: task flatpak-builder:30930 blocked for more than 120 seconds.
  kernel:       Tainted: G        W       4.4.0-98-generic #121-Ubuntu
  kernel: "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
  kernel: flatpak-builder D c0bf5e84     0 30930  30928 0x00000000
  kernel: [<c0bf5e84>] (__schedule) from [<c0bf63c0>] (schedule+0x50/0xa8)
  kernel: [<c0bf63c0>] (schedule) from [<c04a2dfc>] (kmap_high+0x110/0x240)
  kernel: [<c04a2dfc>] (kmap_high) from [<c031f2d4>] (kmap+0x40/0x44)
  kernel: [<c031f2d4>] (kmap) from [<c0512af0>] (write_pipe_buf+0x44/0x88)
  kernel: [<c0512af0>] (write_pipe_buf) from [<c051337c>] (__splice_from_pipe+0x114/0x1a8)
  kernel: [<c051337c>] (__splice_from_pipe) from [<c0514674>] (splice_from_pipe+0x7c/0xa8)
  kernel: [<c0514674>] (splice_from_pipe) from [<c051470c>] (default_file_splice_write+0x34/0x54)
  kernel: [<c051470c>] (default_file_splice_write) from [<c0514aec>] (SyS_splice+0x2f0/0x6cc)
  kernel: [<c0514aec>] (SyS_splice) from [<c0309180>] (ret_fast_syscall+0x0/0x3c)

This is almost certainly an issue with FUSE in the kernel, but just
disable it until it can be properly diagnosed. flatpak-builder will fall
back to doing edits directly in the build directory if rofiles-fuse
can't be found.

https://phabricator.endlessm.com/T18830