### PR TITLE
debian: Add ostree_remote_get_type() to symbols file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+ostree (2017.12-0endless3) unstable; urgency=medium
+
+  * Pull in upstream patches for GIR fixes
+    - https://github.com/ostreedev/ostree/pull/1322
+    - https://github.com/ostreedev/ostree/pull/1337
+
+ -- Philip Withnall <withnall@endlessm.com>  Tue, 14 Nov 2017 18:38:00 +0000
+
 ostree (2017.12-0endless2) unstable; urgency=medium
 
   * Pull in upstream patches before 2017.13 release

--- a/debian/libostree-1-1.symbols
+++ b/debian/libostree-1-1.symbols
@@ -23,6 +23,7 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  LIBOSTREE_2017.12@LIBOSTREE_2017.12 2017.12
  LIBOSTREE_2017.12_EXPERIMENTAL@LIBOSTREE_2017.12_EXPERIMENTAL 2017.12
  LIBOSTREE_2017.13_EXPERIMENTAL@LIBOSTREE_2017.13_EXPERIMENTAL 2017.12-0endless2
+ LIBOSTREE_2017.14_EXPERIMENTAL@LIBOSTREE_2017.14_EXPERIMENTAL 2017.12-0endless3
  ostree_async_progress_finish@LIBOSTREE_2016.3 2016.4
  ostree_async_progress_get@LIBOSTREE_2017.6 2017.6
  ostree_async_progress_get_status@LIBOSTREE_2016.3 2016.4
@@ -148,6 +149,7 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_remote_ref@LIBOSTREE_2017.6_EXPERIMENTAL 2017.8
  ostree_remote_unref@LIBOSTREE_2017.6_EXPERIMENTAL 2017.8
  ostree_remote_get_name@LIBOSTREE_2017.7_EXPERIMENTAL 2017.8
+ ostree_remote_get_type@LIBOSTREE_2017.14_EXPERIMENTAL 2017.12-0endless3
  ostree_repo_abort_transaction@LIBOSTREE_2016.3 2016.4
  ostree_repo_add_gpg_signature_summary@LIBOSTREE_2016.3 2016.4
  ostree_repo_append_gpg_signature@LIBOSTREE_2016.3 2016.4


### PR DESCRIPTION
Put a new release in the changelog, so that other packages can bump
their dependency on OSTree as necessary.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

The Debian part of: https://github.com/endlessm/ostree/pull/95