### PR TITLE
lib/repo: Add (transfer) annotations to various GHashTable arguments

### DIFF
--- a/src/libostree/ostree-repo-finder.c
+++ b/src/libostree/ostree-repo-finder.c
@@ -432,8 +432,8 @@ G_DEFINE_BOXED_TYPE (OstreeRepoFinderResult, ostree_repo_finder_result,
  *    result
  * @priority: static priority of the result, where higher numbers indicate lower
  *    priority
- * @ref_to_checksum: (element-type OstreeCollectionRef utf8): map of collection–ref pairs
- *    to checksums provided by this result
+ * @ref_to_checksum: (element-type OstreeCollectionRef utf8) (transfer none):
+ *    map of collection–ref pairs to checksums provided by this result
  * @summary_last_modified: Unix timestamp (seconds since the epoch, UTC) when
  *    the summary file for the result was last modified, or `0` if this is unknown
  *

--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -717,7 +717,8 @@ _ostree_repo_list_refs_internal (OstreeRepo       *self,
  * ostree_repo_list_refs:
  * @self: Repo
  * @refspec_prefix: (allow-none): Only list refs which match this prefix
- * @out_all_refs: (out) (element-type utf8 utf8): Mapping from ref to checksum
+ * @out_all_refs: (out) (element-type utf8 utf8) (transfer container):
+ *    Mapping from ref to checksum
  * @cancellable: Cancellable
  * @error: Error
  *
@@ -742,7 +743,8 @@ ostree_repo_list_refs (OstreeRepo       *self,
  * ostree_repo_list_refs_ext:
  * @self: Repo
  * @refspec_prefix: (allow-none): Only list refs which match this prefix
- * @out_all_refs: (out) (element-type utf8 utf8): Mapping from ref to checksum
+ * @out_all_refs: (out) (element-type utf8 utf8) (transfer container):
+ *    Mapping from ref to checksum
  * @flags: Options controlling listing behavior
  * @cancellable: Cancellable
  * @error: Error
@@ -770,7 +772,8 @@ ostree_repo_list_refs_ext (OstreeRepo                 *self,
  * ostree_repo_remote_list_refs:
  * @self: Repo
  * @remote_name: Name of the remote.
- * @out_all_refs: (out) (element-type utf8 utf8): Mapping from ref to checksum
+ * @out_all_refs: (out) (element-type utf8 utf8) (transfer container):
+ *    Mapping from ref to checksum
  * @cancellable: Cancellable
  * @error: Error
  *
@@ -885,7 +888,8 @@ remote_list_collection_refs_process_refs (OstreeRepo   *self,
  * ostree_repo_remote_list_collection_refs:
  * @self: Repo
  * @remote_name: Name of the remote.
- * @out_all_refs: (out) (element-type OstreeCollectionRef utf8): Mapping from collection–ref to checksum
+ * @out_all_refs: (out) (element-type OstreeCollectionRef utf8) (transfer container):
+ *    Mapping from collection–ref to checksum
  * @cancellable: Cancellable
  * @error: Error
  *
@@ -1157,7 +1161,8 @@ _ostree_repo_update_collection_refs (OstreeRepo        *self,
  * ostree_repo_list_collection_refs:
  * @self: Repo
  * @match_collection_id: (nullable): If non-%NULL, only list refs from this collection
- * @out_all_refs: (out) (element-type OstreeCollectionRef utf8): Mapping from collection–ref to checksum
+ * @out_all_refs: (out) (element-type OstreeCollectionRef utf8) (transfer container):
+ *    Mapping from collection–ref to checksum
  * @flags: Options controlling listing behavior
  * @cancellable: Cancellable
  * @error: Error

--- a/src/libostree/ostree-soup-form.c
+++ b/src/libostree/ostree-soup-form.c
@@ -82,7 +82,7 @@ encode_pair (GString *str, const char *name, const char *value)
 
 /**
  * soup_form_encode_hash:
- * @form_data_set: (element-type utf8 utf8): a hash table containing
+ * @form_data_set: (element-type utf8 utf8) (transfer none): a hash table containing
  * name/value pairs (as strings)
  *
  * Encodes @form_data_set into a value of type

--- a/src/libostree/ostree-soup-uri.c
+++ b/src/libostree/ostree-soup-uri.c
@@ -1281,7 +1281,7 @@ soup_uri_set_query (SoupURI *uri, const char *query)
 /**
  * soup_uri_set_query_from_form:
  * @uri: a #SoupURI
- * @form: (element-type utf8 utf8): a #GHashTable containing HTML form
+ * @form: (element-type utf8 utf8) (transfer none): a #GHashTable containing HTML form
  * information
  *
  * Sets @uri's query to the result of encoding @form according to the


### PR DESCRIPTION
By default, unless it’s const, an (out) GHashTable will be assumed to be
(transfer full). That means the binding needs to free all the items in
the hash table, plus the table itself.

However, all the GHashTables we use have free functions set already, so
freeing the hash table will free its items. This results in a
double-free.

Fix that by ensuring we annotate such (out) hash tables as (transfer
container). Also annotate some other hash tables as (transfer none)
where appropriate, for clarity.

This fixes OSTree.Repo.list_collection_refs() in the Python bindings.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

Closes: #1341
Approved by: dbnicholson

---

Downstream pull of https://github.com/ostreedev/ostree/pull/1341. It needs to be merged to `xenial` once approved for master.