### PR TITLE
lib/remote: Add a method to return the URL

### DIFF
--- a/apidoc/ostree-experimental-sections.txt
+++ b/apidoc/ostree-experimental-sections.txt
@@ -19,6 +19,7 @@ OstreeRemote
 ostree_remote_ref
 ostree_remote_unref
 ostree_remote_get_name
+ostree_remote_get_url
 <SUBSECTION Standard>
 ostree_remote_get_type
 </SECTION>

--- a/src/libostree/libostree-experimental.sym
+++ b/src/libostree/libostree-experimental.sym
@@ -93,6 +93,7 @@ global:
 LIBOSTREE_2017.14_EXPERIMENTAL {
 global:
   ostree_remote_get_type;
+  ostree_remote_get_url;
   ostree_repo_auto_lock_cleanup;
   ostree_repo_auto_lock_push;
   ostree_repo_lock_pop;

--- a/src/libostree/ostree-remote.c
+++ b/src/libostree/ostree-remote.c
@@ -180,3 +180,21 @@ ostree_remote_get_name (OstreeRemote *remote)
 
   return remote->name;
 }
+
+/**
+ * ostree_remote_get_url:
+ * @remote: an #OstreeRemote
+ *
+ * Get the URL from the remote.
+ *
+ * Returns: (transfer full): the remote's URL
+ * Since: 2017.14
+ */
+gchar *
+ostree_remote_get_url (OstreeRemote *remote)
+{
+  g_return_val_if_fail (remote != NULL, NULL);
+  g_return_val_if_fail (remote->ref_count > 0, NULL);
+
+  return g_key_file_get_string (remote->options, remote->group, "url", NULL);
+}

--- a/src/libostree/ostree-remote.h
+++ b/src/libostree/ostree-remote.h
@@ -57,4 +57,7 @@ void ostree_remote_unref (OstreeRemote *remote);
 _OSTREE_PUBLIC
 const gchar *ostree_remote_get_name (OstreeRemote *remote);
 
+_OSTREE_PUBLIC
+gchar *ostree_remote_get_url (OstreeRemote *remote);
+
 G_END_DECLS

--- a/tests/test-repo-finder-config.c
+++ b/tests/test-repo-finder-config.c
@@ -286,11 +286,13 @@ test_repo_finder_config_mixed_configs (Fixture       *fixture,
           g_assert_cmpuint (g_hash_table_size (result->ref_to_checksum), ==, 2);
           g_assert_true (g_hash_table_contains (result->ref_to_checksum, &ref0));
           g_assert_true (g_hash_table_contains (result->ref_to_checksum, &ref1));
+          g_assert_cmpstr (ostree_remote_get_url (result->remote), ==, collection0_uri);
         }
       else if (g_strcmp0 (ostree_remote_get_name (result->remote), "remote1") == 0)
         {
           g_assert_cmpuint (g_hash_table_size (result->ref_to_checksum), ==, 1);
           g_assert_true (g_hash_table_contains (result->ref_to_checksum, &ref3));
+          g_assert_cmpstr (ostree_remote_get_url (result->remote), ==, collection1_uri);
         }
       else
         {


### PR DESCRIPTION
When using dynamic remotes (LAN and USB), we cannot use their name with
the common remote related ops (ostree_repo_remote_...) because ostree
doesn't keep this type of remotes in its internal hash table.
Unfortunately this means that we cannot access the URL of those remotes
either (in order to e.g. set the right URL for those remotes in
Flatpak).

Since the URL is actually stored in a key file that belongs to the
OstreeRemote, then we can simply allow users access to it through a
getter.

So this patch adds a method that allows to return the URL directly from
the OstreeRemote without having to go through the OstreeRepo.

The test-repo-finder-config is also updated by this patch to check if
the URL is correct.

Merged upstream as a1745e1a79ea1c41cc62e91b346a2a9961997a76.

https://phabricator.endlessm.com/T20078