### PR TITLE
Remove ostree_repo_delete_compat_signature from symbols file

### DIFF
--- a/debian/libostree-1-1.symbols
+++ b/debian/libostree-1-1.symbols
@@ -178,7 +178,6 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_repo_copy_config@LIBOSTREE_2016.3 2016.4
  ostree_repo_create@LIBOSTREE_2016.3 2016.4
  ostree_repo_create_at@LIBOSTREE_2017.10 2017.10
- ostree_repo_delete_compat_signature@LIBOSTREE_2016.3 2016.3
  ostree_repo_delete_object@LIBOSTREE_2016.3 2016.4
  ostree_repo_devino_cache_get_type@LIBOSTREE_2016.3 2016.4
  ostree_repo_devino_cache_new@LIBOSTREE_2016.3 2016.4


### PR DESCRIPTION
This was an API added to support writing the compat signature files from
the ostree gpg-sign builtin. Both that usage and the symbol itself have
been removed since the compat signatures are no longer being created.

See #103 for main branch PR.

https://phabricator.endlessm.com/T17367