### PR TITLE
debian: Compile with avahi support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,8 @@ Build-Depends:
  gtk-doc-tools <!nodoc>,
  libarchive-dev,
  libattr1-dev,
+ libavahi-client-dev,
+ libavahi-glib-dev,
  libcap-dev,
  libfuse-dev,
  libgirepository1.0-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,7 @@ configure_options = \
 	--with-systemdsystemgeneratordir=/lib/systemd/system-generators \
 	--with-systemdsystemunitdir=/lib/systemd/system \
 	BASH_COMPLETIONSDIR=/usr/share/bash-completion/completions \
+	--with-avahi \
 	$(NULL)
 
 ifeq (,$(filter nodoc,$(DEB_BUILD_PROFILES)))


### PR DESCRIPTION
Add avahi-glib as a build dependency and use the configure option
--with-avahi to try to ensure that ostree compiles with avahi support,
which is necessary for P2P updates to work.

https://phabricator.endlessm.com/T20662