### PR TITLE
avahi: Don't complain with g_warning if the daemon wasn't running

### DIFF
--- a/src/libostree/ostree-repo-finder-avahi.c
+++ b/src/libostree/ostree-repo-finder-avahi.c
@@ -1435,9 +1435,15 @@ ostree_repo_finder_avahi_start (OstreeRepoFinderAvahi  *self,
 
   if (client == NULL)
     {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                   "Failed to create finder client: %s",
-                   avahi_strerror (failure));
+      if (failure == AVAHI_ERR_NO_DAEMON)
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+                     "Avahi daemon is not running: %s",
+                     avahi_strerror (failure));
+      else
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                     "Failed to create finder client: %s",
+                     avahi_strerror (failure));
+
       return;
     }
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -4592,7 +4592,20 @@ ostree_repo_find_remotes_async (OstreeRepo                     *self,
 
       if (local_error != NULL)
         {
-          g_warning ("Avahi finder failed; removing it: %s", local_error->message);
+          /* See ostree-repo-finder-avahi.c:ostree_repo_finder_avahi_start, we
+           * intentionally throw this so as to distinguish between the Avahi
+           * finder failing because the Avahi daemon wasn't running and
+           * the Avahi finder failing because of some actual error.
+           *
+           * We need to distinguish between g_debug and g_warning here because
+           * unit tests that use this code may set G_DEBUG=fatal-warnings which
+           * would cause client code to abort if a warning were emitted.
+           */
+          if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+            g_debug ("Avahi finder failed under normal operation; removing it: %s", local_error->message);
+          else
+            g_warning ("Avahi finder failed abnormally; removing it: %s", local_error->message);
+
           default_finders[2] = NULL;
           g_clear_object (&finder_avahi);
         }


### PR DESCRIPTION
This is a normal case when running unit tests in client code
on continuous integration infrastructure. When those tests are
running they will set G_DEBUG=fatal-warnings which will cause
the program to abort if a warning is emitted. Instead, emit
a debug message if the problem was that we couldn't connect to
the daemon.

https://phabricator.endlessm.com/T16682