### PR TITLE
pull: Ignore the cancellable when aborting a transaction

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -1756,6 +1756,12 @@ ostree_repo_abort_transaction (OstreeRepo     *self,
                                GCancellable   *cancellable,
                                GError        **error)
 {
+  /* Always ignore the cancellable to avoid the chance that, if it gets
+   * canceled, the transaction may not be fully cleaned up.
+   * See https://github.com/ostreedev/ostree/issues/1491 .
+   */
+  cancellable = NULL;
+
   /* Note early return */
   if (!self->in_transaction)
     return TRUE;


### PR DESCRIPTION
In ostree_repo_abort_transaction, if we pass a cancellable and it gets
canceled, then the function may fail to fully clean up the transaction
state. This was happening e.g. when the ostree_repo_pull_with_options
call got cancelled.

To fix this, as suggested by Colin Walters, we set the passed
cancellable as NULL, in order for it to be ignored.

https://github.com/ostreedev/ostree/issues/1491