### PR TITLE
lib/deploy: Always append index to bootloader title

### DIFF
--- a/src/libostree/ostree-sysroot-deploy.c
+++ b/src/libostree/ostree-sysroot-deploy.c
@@ -1783,10 +1783,7 @@ install_deployment_kernel (OstreeSysroot   *sysroot,
       g_string_append_c (title_key, ':');
       g_string_append (title_key, osname);
     }
-  if (!(deployment_version && *deployment_version))
-    {
-      g_string_append_printf (title_key, ":%d", ostree_deployment_get_index (deployment));
-    }
+  g_string_append_printf (title_key, ":%d", ostree_deployment_get_index (deployment));
   g_string_append_c (title_key, ')');
   ostree_bootconfig_parser_set (bootconfig, "title", title_key->str);
 


### PR DESCRIPTION
Without this, a previous entry with a deployment version found from the
version metadata would not have it's entry changed when a new deployment
is installed. That's a problem with our grub implementation that will
continue to boot the previous entry as long as it can find its title.
Without appending the deployment index, it will never change.

https://phabricator.endlessm.com/T22114