### PR TITLE
T22555 Retry downloads on flaky networks

### DIFF
--- a/src/libostree/ostree-fetcher-curl.c
+++ b/src/libostree/ostree-fetcher-curl.c
@@ -337,19 +337,7 @@ check_multi_info (OstreeFetcher *fetcher)
           curl_easy_getinfo (easy, CURLINFO_RESPONSE_CODE, &response);
           if (!is_file && !(response >= 200 && response < 300))
             {
-              GIOErrorEnum giocode;
-
-              /* TODO - share with soup */
-              switch (response)
-                {
-                case 404:
-                case 403:
-                case 410:
-                  giocode = G_IO_ERROR_NOT_FOUND;
-                  break;
-                default:
-                  giocode = G_IO_ERROR_FAILED;
-                }
+              GIOErrorEnum giocode = _ostree_fetcher_http_status_code_to_io_error (response);
 
               if (req->idx + 1 == req->mirrorlist->len)
                 {

--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -1072,10 +1072,27 @@ on_request_sent (GObject        *object,
               GIOErrorEnum code;
               switch (msg->status_code)
                 {
-                case 404:
-                case 403:
-                case 410:
+                case SOUP_STATUS_NOT_FOUND:
+                case SOUP_STATUS_FORBIDDEN:
+                case SOUP_STATUS_GONE:
                   code = G_IO_ERROR_NOT_FOUND;
+                  break;
+                case SOUP_STATUS_CANCELLED:
+                  code = G_IO_ERROR_CANCELLED;
+                  break;
+                case SOUP_STATUS_REQUEST_TIMEOUT:
+                  code = G_IO_ERROR_TIMED_OUT;
+                  break;
+                case SOUP_STATUS_CANT_RESOLVE:
+                case SOUP_STATUS_CANT_CONNECT:
+                  code = G_IO_ERROR_HOST_NOT_FOUND;
+                  break;
+                case SOUP_STATUS_IO_ERROR:
+#if !GLIB_CHECK_VERSION(2, 44, 0)
+                  code = G_IO_ERROR_BROKEN_PIPE;
+#else
+                  code = G_IO_ERROR_CONNECTION_CLOSED;
+#endif
                   break;
                 default:
                   code = G_IO_ERROR_FAILED;

--- a/src/libostree/ostree-fetcher-soup.c
+++ b/src/libostree/ostree-fetcher-soup.c
@@ -1070,18 +1070,12 @@ on_request_sent (GObject        *object,
                 soup_uri_to_string (soup_request_get_uri (pending->request), FALSE);
 
               GIOErrorEnum code;
+
               switch (msg->status_code)
                 {
-                case SOUP_STATUS_NOT_FOUND:
-                case SOUP_STATUS_FORBIDDEN:
-                case SOUP_STATUS_GONE:
-                  code = G_IO_ERROR_NOT_FOUND;
-                  break;
+                /* These statuses are internal to libsoup, and not standard HTTP ones: */
                 case SOUP_STATUS_CANCELLED:
                   code = G_IO_ERROR_CANCELLED;
-                  break;
-                case SOUP_STATUS_REQUEST_TIMEOUT:
-                  code = G_IO_ERROR_TIMED_OUT;
                   break;
                 case SOUP_STATUS_CANT_RESOLVE:
                 case SOUP_STATUS_CANT_CONNECT:
@@ -1095,7 +1089,8 @@ on_request_sent (GObject        *object,
 #endif
                   break;
                 default:
-                  code = G_IO_ERROR_FAILED;
+                  code = _ostree_fetcher_http_status_code_to_io_error (msg->status_code);
+                  break;
                 }
 
               {

--- a/src/libostree/ostree-fetcher-util.c
+++ b/src/libostree/ostree-fetcher-util.c
@@ -218,3 +218,22 @@ _ostree_fetcher_should_retry_request (const GError *error,
 
   return FALSE;
 }
+
+/* Convert a HTTP status code representing an error from libsoup or libcurl to
+ * a #GIOError. This will return %G_IO_ERROR_FAILED if the status code is
+ * unknown or otherwise unhandled. */
+GIOError
+_ostree_fetcher_http_status_code_to_io_error (guint status_code)
+{
+  switch (status_code)
+    {
+    case 403:  /* SOUP_STATUS_FORBIDDEN */
+    case 404:  /* SOUP_STATUS_NOT_FOUND */
+    case 410:  /* SOUP_STATUS_GONE */
+      return G_IO_ERROR_NOT_FOUND;
+    case 408:  /* SOUP_STATUS_REQUEST_TIMEOUT */
+      return G_IO_ERROR_TIMED_OUT;
+    default:
+      return G_IO_ERROR_FAILED;
+    }
+}

--- a/src/libostree/ostree-fetcher-util.c
+++ b/src/libostree/ostree-fetcher-util.c
@@ -52,15 +52,15 @@ fetch_uri_sync_on_complete (GObject        *object,
   data->done = TRUE;
 }
 
-gboolean
-_ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher  *fetcher,
-                                            GPtrArray     *mirrorlist,
-                                            const char     *filename,
-                                            OstreeFetcherRequestFlags flags,
-                                            GBytes         **out_contents,
-                                            guint64        max_size,
-                                            GCancellable   *cancellable,
-                                            GError         **error)
+static gboolean
+_ostree_fetcher_mirrored_request_to_membuf_once  (OstreeFetcher              *fetcher,
+                                                  GPtrArray                  *mirrorlist,
+                                                  const char                 *filename,
+                                                  OstreeFetcherRequestFlags   flags,
+                                                  GBytes                    **out_contents,
+                                                  guint64                     max_size,
+                                                  GCancellable               *cancellable,
+                                                  GError                    **error)
 {
   gboolean ret = FALSE;
   g_autoptr(GMainContext) mainctx = NULL;
@@ -108,11 +108,42 @@ _ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher  *fetcher,
   return ret;
 }
 
+gboolean
+_ostree_fetcher_mirrored_request_to_membuf  (OstreeFetcher              *fetcher,
+                                             GPtrArray                  *mirrorlist,
+                                             const char                 *filename,
+                                             OstreeFetcherRequestFlags   flags,
+                                             guint                       n_network_retries,
+                                             GBytes                    **out_contents,
+                                             guint64                     max_size,
+                                             GCancellable               *cancellable,
+                                             GError                    **error)
+{
+  g_autoptr(GError) local_error = NULL;
+  guint n_retries_remaining = n_network_retries;
+
+  do
+    {
+      g_clear_error (&local_error);
+      if (_ostree_fetcher_mirrored_request_to_membuf_once (fetcher, mirrorlist,
+                                                           filename, flags,
+                                                           out_contents, max_size,
+                                                           cancellable, &local_error))
+        return TRUE;
+    }
+  while (_ostree_fetcher_should_retry_request (local_error, n_retries_remaining--));
+
+  g_assert (local_error != NULL);
+  g_propagate_error (error, g_steal_pointer (&local_error));
+  return FALSE;
+}
+
 /* Helper for callers who just want to fetch single one-off URIs */
 gboolean
 _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
                                        OstreeFetcherURI *uri,
                                        OstreeFetcherRequestFlags flags,
+                                       guint          n_network_retries,
                                        GBytes         **out_contents,
                                        guint64        max_size,
                                        GCancellable   *cancellable,
@@ -121,7 +152,7 @@ _ostree_fetcher_request_uri_to_membuf (OstreeFetcher  *fetcher,
   g_autoptr(GPtrArray) mirrorlist = g_ptr_array_new ();
   g_ptr_array_add (mirrorlist, uri); /* no transfer */
   return _ostree_fetcher_mirrored_request_to_membuf (fetcher, mirrorlist, NULL, flags,
-                                                     out_contents, max_size,
+                                                     n_network_retries, out_contents, max_size,
                                                      cancellable, error);
 }
 
@@ -143,4 +174,47 @@ _ostree_fetcher_journal_failure (const char *remote_name,
                    "OSTREE_URL=%s", url,
                    NULL);
 #endif
+}
+
+/* Check whether a particular operation should be retried. This is entirely
+ * based on how it failed (if at all) last time, and whether the operation has
+ * some retries left. The retry count is set when the operation is first
+ * created, and must be decremented by the caller. (@n_retries_remaining == 0)
+ * will always return %FALSE from this function.
+ *
+ * FIXME: In future, we may decide to use transient failures like this as a hint
+ * to prioritise other mirrors for a particular pull operation (for example). */
+gboolean
+_ostree_fetcher_should_retry_request (const GError *error,
+                                      guint         n_retries_remaining)
+{
+  if (error == NULL)
+    g_debug ("%s: error: unset, n_retries_remaining: %u",
+             G_STRFUNC, n_retries_remaining);
+  else
+    g_debug ("%s: error: %u:%u %s, n_retries_remaining: %u",
+             G_STRFUNC, error->domain, error->code, error->message,
+             n_retries_remaining);
+
+  if (error == NULL || n_retries_remaining == 0)
+    return FALSE;
+
+  /* Return TRUE for transient errors. */
+  if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_TIMED_OUT) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND) ||
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_HOST_UNREACHABLE) ||
+#if !GLIB_CHECK_VERSION(2, 44, 0)
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_BROKEN_PIPE) ||
+#else
+      g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED) ||
+#endif
+      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_NOT_FOUND) ||
+      g_error_matches (error, G_RESOLVER_ERROR, G_RESOLVER_ERROR_TEMPORARY_FAILURE))
+    {
+      g_debug ("Should retry request (remaining: %u retries), due to transient error: %s",
+               n_retries_remaining, error->message);
+      return TRUE;
+    }
+
+  return FALSE;
 }

--- a/src/libostree/ostree-fetcher-util.h
+++ b/src/libostree/ostree-fetcher-util.h
@@ -78,6 +78,8 @@ void _ostree_fetcher_journal_failure (const char *remote_name,
 gboolean _ostree_fetcher_should_retry_request (const GError *error,
                                                guint         n_retries_remaining);
 
+GIOError _ostree_fetcher_http_status_code_to_io_error (guint status_code);
+
 G_END_DECLS
 
 #endif

--- a/src/libostree/ostree-fetcher-util.h
+++ b/src/libostree/ostree-fetcher-util.h
@@ -56,6 +56,7 @@ gboolean _ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher *fetcher,
                                                      GPtrArray     *mirrorlist,
                                                      const char    *filename,
                                                      OstreeFetcherRequestFlags flags,
+                                                     guint          n_network_retries,
                                                      GBytes         **out_contents,
                                                      guint64        max_size,
                                                      GCancellable   *cancellable,
@@ -64,6 +65,7 @@ gboolean _ostree_fetcher_mirrored_request_to_membuf (OstreeFetcher *fetcher,
 gboolean _ostree_fetcher_request_uri_to_membuf (OstreeFetcher *fetcher,
                                                 OstreeFetcherURI *uri,
                                                 OstreeFetcherRequestFlags flags,
+                                                guint          n_network_retries,
                                                 GBytes         **out_contents,
                                                 guint64        max_size,
                                                 GCancellable   *cancellable,
@@ -73,6 +75,8 @@ void _ostree_fetcher_journal_failure (const char *remote_name,
                                       const char *url,
                                       const char *msg);
 
+gboolean _ostree_fetcher_should_retry_request (const GError *error,
+                                               guint         n_retries_remaining);
 
 G_END_DECLS
 

--- a/src/libostree/ostree-metalink.h
+++ b/src/libostree/ostree-metalink.h
@@ -48,7 +48,8 @@ GType   _ostree_metalink_get_type (void) G_GNUC_CONST;
 OstreeMetalink *_ostree_metalink_new (OstreeFetcher  *fetcher,
                                       const char     *requested_file,
                                       guint64         max_size,
-                                      OstreeFetcherURI *uri);
+                                      OstreeFetcherURI *uri,
+                                      guint             n_network_retries);
 
 gboolean _ostree_metalink_request_sync (OstreeMetalink        *self,
                                         OstreeFetcherURI      **out_target_uri,

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1941,12 +1941,11 @@ enqueue_one_object_request (OtPullData                *pull_data,
     {
       g_debug ("queuing fetch of %s.%s%s", checksum,
                ostree_object_type_to_string (objtype),
-               is_detached_meta ? " (detached)" : "");
+               fetch_data->is_detached_meta ? " (detached)" : "");
 
       if (is_meta)
         {
-          GVariant *objname = ostree_object_name_serialize (checksum, objtype);
-          g_hash_table_insert (pull_data->pending_fetch_metadata, objname, fetch_data);
+          g_hash_table_insert (pull_data->pending_fetch_metadata, g_variant_ref (fetch_data->object), fetch_data);
         }
       else
         {

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2489,13 +2489,13 @@ on_superblock_fetched (GObject   *src,
                        gpointer      data)
 
 {
-  FetchDeltaSuperData *fdata = data;
-  OtPullData *pull_data = fdata->pull_data;
+  FetchDeltaSuperData *fetch_data = data;
+  OtPullData *pull_data = fetch_data->pull_data;
   g_autoptr(GError) local_error = NULL;
   GError **error = &local_error;
   g_autoptr(GBytes) delta_superblock_data = NULL;
-  const char *from_revision = fdata->from_revision;
-  const char *to_revision = fdata->to_revision;
+  const char *from_revision = fetch_data->from_revision;
+  const char *to_revision = fetch_data->to_revision;
 
   if (!_ostree_fetcher_request_to_membuf_finish ((OstreeFetcher*)src,
                                                  res,
@@ -2512,7 +2512,7 @@ on_superblock_fetched (GObject   *src,
           goto out;
         }
 
-      queue_scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT, NULL, 0, fdata->requested_ref);
+      queue_scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT, NULL, 0, fetch_data->requested_ref);
     }
   else
     {
@@ -2547,7 +2547,7 @@ on_superblock_fetched (GObject   *src,
                                                                        delta_superblock_data, FALSE));
 
       g_ptr_array_add (pull_data->static_delta_superblocks, g_variant_ref (delta_superblock));
-      if (!process_one_static_delta (pull_data, from_revision, to_revision, delta_superblock, fdata->requested_ref,
+      if (!process_one_static_delta (pull_data, from_revision, to_revision, delta_superblock, fetch_data->requested_ref,
                                      pull_data->cancellable, error))
         goto out;
     }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -226,6 +226,8 @@ static void queue_scan_one_metadata_object_c (OtPullData                *pull_da
 
 static void enqueue_one_object_request_s (OtPullData      *pull_data,
                                           FetchObjectData *fetch_data);
+static void enqueue_one_static_delta_part_request_s (OtPullData           *pull_data,
+                                                     FetchStaticDeltaData *fetch_data);
 
 static gboolean scan_one_metadata_object (OtPullData                 *pull_data,
                                           const char                 *checksum,
@@ -2134,6 +2136,24 @@ process_one_static_delta_fallback (OtPullData   *pull_data,
 }
 
 static void
+enqueue_one_static_delta_part_request_s (OtPullData           *pull_data,
+                                         FetchStaticDeltaData *fetch_data)
+{
+  if (fetcher_queue_is_full (pull_data))
+    {
+      g_debug ("queuing fetch of static delta %s-%s part %u",
+               fetch_data->from_revision ?: "empty",
+               fetch_data->to_revision, fetch_data->i);
+
+      g_hash_table_add (pull_data->pending_fetch_deltaparts, fetch_data);
+    }
+  else
+    {
+      start_fetch_deltapart (pull_data, fetch_data);
+    }
+}
+
+static void
 start_fetch_deltapart (OtPullData *pull_data,
                        FetchStaticDeltaData *fetch)
 {
@@ -2315,12 +2335,7 @@ process_one_static_delta (OtPullData                 *pull_data,
         }
       else
         {
-          if (!fetcher_queue_is_full (pull_data))
-            start_fetch_deltapart (pull_data, fetch_data);
-          else
-            {
-              g_hash_table_add (pull_data->pending_fetch_deltaparts, fetch_data);
-            }
+          enqueue_one_static_delta_part_request_s (pull_data, g_steal_pointer (&fetch_data));
         }
     }
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -61,6 +61,12 @@
 #define OSTREE_REPO_PULL_CONTENT_PRIORITY  (OSTREE_FETCHER_DEFAULT_PRIORITY)
 #define OSTREE_REPO_PULL_METADATA_PRIORITY (OSTREE_REPO_PULL_CONTENT_PRIORITY - 100)
 
+/* Arbitrarily chosen number of retries for all download operations when they
+ * receive a transient network error (such as a socket timeout) — see
+ * _ostree_fetcher_should_retry_request(). This is the default value for the
+ * `n-network-retries` pull option. */
+#define DEFAULT_N_NETWORK_RETRIES 5
+
 typedef enum {
   OSTREE_FETCHER_SECURITY_STATE_CA_PINNED,
   OSTREE_FETCHER_SECURITY_STATE_TLS,
@@ -92,6 +98,7 @@ typedef struct {
   gboolean      dry_run;
   gboolean      dry_run_emitted_progress;
   gboolean      legacy_transaction_resuming;
+  guint         n_network_retries;
   enum {
     OSTREE_PULL_PHASE_FETCHING_REFS,
     OSTREE_PULL_PHASE_FETCHING_OBJECTS
@@ -177,6 +184,7 @@ typedef struct {
   gboolean     object_is_stored;
 
   OstreeCollectionRef *requested_ref;  /* (nullable) */
+  guint n_retries_remaining;
 } FetchObjectData;
 
 typedef struct {
@@ -187,6 +195,7 @@ typedef struct {
   char *to_revision;
   guint i;
   guint64 size;
+  guint n_retries_remaining;
 } FetchStaticDeltaData;
 
 typedef struct {
@@ -504,6 +513,8 @@ idle_worker (gpointer user_data)
   scan_one_metadata_object (pull_data, checksum, scan_data->objtype,
                             scan_data->path, scan_data->recursion_depth,
                             scan_data->requested_ref, pull_data->cancellable, &error);
+
+  /* No need to retry scan tasks, since they’re local. */
   check_outstanding_requests_handle_error (pull_data, &error);
   scan_object_queue_data_free (scan_data);
 
@@ -534,6 +545,7 @@ static gboolean
 fetch_mirrored_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
                                        GPtrArray      *mirrorlist,
                                        const char     *filename,
+                                       guint           n_network_retries,
                                        char          **out_contents,
                                        GCancellable   *cancellable,
                                        GError        **error)
@@ -541,6 +553,7 @@ fetch_mirrored_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
   g_autoptr(GBytes) bytes = NULL;
   if (!_ostree_fetcher_mirrored_request_to_membuf (fetcher, mirrorlist,
                                                    filename, OSTREE_FETCHER_REQUEST_NUL_TERMINATION,
+                                                   n_network_retries,
                                                    &bytes,
                                                    OSTREE_MAX_METADATA_SIZE,
                                                    cancellable, error))
@@ -559,6 +572,7 @@ fetch_mirrored_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
 static gboolean
 fetch_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
                               OstreeFetcherURI *uri,
+                              guint           n_network_retries,
                               char          **out_contents,
                               GCancellable   *cancellable,
                               GError        **error)
@@ -566,7 +580,8 @@ fetch_uri_contents_utf8_sync (OstreeFetcher  *fetcher,
   g_autoptr(GPtrArray) mirrorlist = g_ptr_array_new ();
   g_ptr_array_add (mirrorlist, uri); /* no transfer */
   return fetch_mirrored_uri_contents_utf8_sync (fetcher, mirrorlist,
-                                                NULL, out_contents,
+                                                NULL, n_network_retries,
+                                                out_contents,
                                                 cancellable, error);
 }
 
@@ -720,6 +735,7 @@ on_local_object_imported (GObject        *object,
   pull_data->n_imported_content++;
   g_assert_cmpint (pull_data->n_outstanding_content_write_requests, >, 0);
   pull_data->n_outstanding_content_write_requests--;
+  /* No retries for local reads. */
   check_outstanding_requests_handle_error (pull_data, &local_error);
 }
 
@@ -895,7 +911,8 @@ fetch_ref_contents (OtPullData                 *pull_data,
 
       if (!fetch_mirrored_uri_contents_utf8_sync (pull_data->fetcher,
                                                   pull_data->meta_mirrorlist,
-                                                  filename, &ret_contents,
+                                                  filename, pull_data->n_network_retries,
+                                                  &ret_contents,
                                                   cancellable, error))
         return FALSE;
 
@@ -1019,6 +1036,7 @@ content_fetch_on_write_complete (GObject        *object,
     pull_data->n_fetched_deltapart_fallbacks++;
  out:
   pull_data->n_outstanding_content_write_requests--;
+  /* No retries for local writes. */
   check_outstanding_requests_handle_error (pull_data, &local_error);
   fetch_object_data_free (fetch_data);
 }
@@ -1104,9 +1122,14 @@ content_fetch_on_complete (GObject        *object,
 
  out:
   pull_data->n_outstanding_content_fetches--;
-  check_outstanding_requests_handle_error (pull_data, &local_error);
+
+  if (_ostree_fetcher_should_retry_request (local_error, fetch_data->n_retries_remaining--))
+    enqueue_one_object_request_s (pull_data, g_steal_pointer (&fetch_data));
+  else
+    check_outstanding_requests_handle_error (pull_data, &local_error);
+
   if (free_fetch_data)
-    fetch_object_data_free (fetch_data);
+    g_clear_pointer (&fetch_data, fetch_object_data_free);
 }
 
 static void
@@ -1150,6 +1173,7 @@ on_metadata_written (GObject           *object,
   pull_data->n_outstanding_metadata_write_requests--;
   fetch_object_data_free (fetch_data);
 
+  /* No need to retry local write operations. */
   check_outstanding_requests_handle_error (pull_data, &local_error);
 }
 
@@ -1287,10 +1311,17 @@ meta_fetch_on_complete (GObject           *object,
  out:
   g_assert (pull_data->n_outstanding_metadata_fetches > 0);
   pull_data->n_outstanding_metadata_fetches--;
-  pull_data->n_fetched_metadata++;
-  check_outstanding_requests_handle_error (pull_data, &local_error);
+
+  if (local_error == NULL)
+    pull_data->n_fetched_metadata++;
+
+  if (_ostree_fetcher_should_retry_request (local_error, fetch_data->n_retries_remaining--))
+    enqueue_one_object_request_s (pull_data, g_steal_pointer (&fetch_data));
+  else
+    check_outstanding_requests_handle_error (pull_data, &local_error);
+
   if (free_fetch_data)
-    fetch_object_data_free (fetch_data);
+    g_clear_pointer (&fetch_data, fetch_object_data_free);
 }
 
 static void
@@ -1322,6 +1353,7 @@ on_static_delta_written (GObject           *object,
  out:
   g_assert (pull_data->n_outstanding_deltapart_write_requests > 0);
   pull_data->n_outstanding_deltapart_write_requests--;
+  /* No need to retry on failure to write locally. */
   check_outstanding_requests_handle_error (pull_data, &local_error);
   /* Always free state */
   fetch_static_delta_data_free (fetch_data);
@@ -1367,10 +1399,17 @@ static_deltapart_fetch_on_complete (GObject           *object,
  out:
   g_assert (pull_data->n_outstanding_deltapart_fetches > 0);
   pull_data->n_outstanding_deltapart_fetches--;
-  pull_data->n_fetched_deltaparts++;
-  check_outstanding_requests_handle_error (pull_data, &local_error);
+
+  if (local_error == NULL)
+    pull_data->n_fetched_deltaparts++;
+
+  if (_ostree_fetcher_should_retry_request (local_error, fetch_data->n_retries_remaining--))
+    enqueue_one_static_delta_part_request_s (pull_data, g_steal_pointer (&fetch_data));
+  else
+    check_outstanding_requests_handle_error (pull_data, &local_error);
+
   if (free_fetch_data)
-    fetch_static_delta_data_free (fetch_data);
+    g_clear_pointer (&fetch_data, fetch_static_delta_data_free);
 }
 
 static gboolean
@@ -1973,10 +2012,9 @@ enqueue_one_object_request (OtPullData                *pull_data,
   fetch_data->is_detached_meta = is_detached_meta;
   fetch_data->object_is_stored = object_is_stored;
   fetch_data->requested_ref = (ref != NULL) ? ostree_collection_ref_dup (ref) : NULL;
+  fetch_data->n_retries_remaining = pull_data->n_network_retries;
 
-  gboolean is_meta = OSTREE_OBJECT_TYPE_IS_META (objtype);
-
-  if (is_meta)
+  if (OSTREE_OBJECT_TYPE_IS_META (objtype))
     pull_data->n_requested_metadata++;
   else
     pull_data->n_requested_content++;
@@ -2056,8 +2094,8 @@ load_remote_repo_config (OtPullData    *pull_data,
 
   if (!fetch_mirrored_uri_contents_utf8_sync (pull_data->fetcher,
                                               pull_data->meta_mirrorlist,
-                                              "config", &contents,
-                                              cancellable, error))
+                                              "config", pull_data->n_network_retries,
+                                              &contents, cancellable, error))
     return FALSE;
 
   g_autoptr(GKeyFile) ret_keyfile = g_key_file_new ();
@@ -2239,6 +2277,7 @@ process_one_static_delta (OtPullData                 *pull_data,
           fetch_data->is_detached_meta = FALSE;
           fetch_data->object_is_stored = FALSE;
           fetch_data->requested_ref = (ref != NULL) ? ostree_collection_ref_dup (ref) : NULL;
+          fetch_data->n_retries_remaining = pull_data->n_network_retries;
 
           ostree_repo_write_metadata_async (pull_data->repo, OSTREE_OBJECT_TYPE_COMMIT, to_checksum,
                                             to_commit,
@@ -2312,6 +2351,7 @@ process_one_static_delta (OtPullData                 *pull_data,
       fetch_data->expected_checksum = ostree_checksum_from_bytes_v (csum_v);
       fetch_data->size = size;
       fetch_data->i = i;
+      fetch_data->n_retries_remaining = pull_data->n_network_retries;
 
       if (inline_part_bytes != NULL)
         {
@@ -2594,7 +2634,11 @@ on_superblock_fetched (GObject   *src,
  out:
   g_assert (pull_data->n_outstanding_metadata_fetches > 0);
   pull_data->n_outstanding_metadata_fetches--;
-  pull_data->n_fetched_metadata++;
+
+  if (local_error == NULL)
+    pull_data->n_fetched_metadata++;
+
+  /* FIXME: This should check _ostree_fetcher_should_retry_request(). */
   check_outstanding_requests_handle_error (pull_data, &local_error);
 
   g_clear_pointer (&fetch_data, fetch_delta_super_data_free);
@@ -2827,6 +2871,7 @@ _ostree_preload_metadata_file (OstreeRepo    *self,
                                GPtrArray     *mirrorlist,
                                const char    *filename,
                                gboolean      is_metalink,
+                               guint         n_network_retries,
                                GBytes        **out_bytes,
                                GCancellable  *cancellable,
                                GError        **error)
@@ -2840,7 +2885,7 @@ _ostree_preload_metadata_file (OstreeRepo    *self,
       g_autoptr(OstreeMetalink) metalink =
         _ostree_metalink_new (fetcher, filename,
                               OSTREE_MAX_METADATA_SIZE,
-                              mirrorlist->pdata[0]);
+                              mirrorlist->pdata[0], n_network_retries);
 
       _ostree_metalink_request_sync (metalink, NULL, out_bytes,
                                      cancellable, &local_error);
@@ -2862,6 +2907,7 @@ _ostree_preload_metadata_file (OstreeRepo    *self,
     {
       return _ostree_fetcher_mirrored_request_to_membuf (fetcher, mirrorlist, filename,
                                                          OSTREE_FETCHER_REQUEST_OPTIONAL_CONTENT,
+                                                         n_network_retries,
                                                          out_bytes, OSTREE_MAX_METADATA_SIZE,
                                                          cancellable, error);
     }
@@ -2870,6 +2916,7 @@ _ostree_preload_metadata_file (OstreeRepo    *self,
 static gboolean
 fetch_mirrorlist (OstreeFetcher  *fetcher,
                   const char     *mirrorlist_url,
+                  guint           n_network_retries,
                   GPtrArray     **out_mirrorlist,
                   GCancellable   *cancellable,
                   GError        **error)
@@ -2882,8 +2929,8 @@ fetch_mirrorlist (OstreeFetcher  *fetcher,
     return FALSE;
 
   g_autofree char *contents = NULL;
-  if (!fetch_uri_contents_utf8_sync (fetcher, mirrorlist, &contents,
-                                     cancellable, error))
+  if (!fetch_uri_contents_utf8_sync (fetcher, mirrorlist, n_network_retries,
+                                     &contents, cancellable, error))
     return glnx_prefix_error (error, "While fetching mirrorlist '%s'",
                               mirrorlist_url);
 
@@ -2929,8 +2976,8 @@ fetch_mirrorlist (OstreeFetcher  *fetcher,
           GError *local_error = NULL;
           g_autoptr(OstreeFetcherURI) config_uri = _ostree_fetcher_uri_new_subpath (mirror_uri, "config");
 
-          if (fetch_uri_contents_utf8_sync (fetcher, config_uri, NULL,
-                                            cancellable, &local_error))
+          if (fetch_uri_contents_utf8_sync (fetcher, config_uri, n_network_retries,
+                                            NULL, cancellable, &local_error))
             g_ptr_array_add (ret_mirrorlist, g_steal_pointer (&mirror_uri));
           else
             {
@@ -2971,12 +3018,14 @@ repo_remote_fetch_summary (OstreeRepo    *self,
   g_autoptr(GVariant) extra_headers = NULL;
   g_autoptr(GPtrArray) mirrorlist = NULL;
   const char *append_user_agent = NULL;
+  guint n_network_retries = DEFAULT_N_NETWORK_RETRIES;
 
   if (options)
     {
       (void) g_variant_lookup (options, "override-url", "&s", &url_override);
       (void) g_variant_lookup (options, "http-headers", "@a(ss)", &extra_headers);
       (void) g_variant_lookup (options, "append-user-agent", "&s", &append_user_agent);
+      (void) g_variant_lookup (options, "n-network-retries", "&u", &n_network_retries);
     }
 
   mainctx = g_main_context_new ();
@@ -3005,7 +3054,7 @@ repo_remote_fetch_summary (OstreeRepo    *self,
         g_str_has_prefix (url_string, "mirrorlist="))
       {
         if (!fetch_mirrorlist (fetcher, url_string + strlen ("mirrorlist="),
-                               &mirrorlist, cancellable, error))
+                               n_network_retries, &mirrorlist, cancellable, error))
           goto out;
       }
     else
@@ -3031,6 +3080,7 @@ repo_remote_fetch_summary (OstreeRepo    *self,
                                       mirrorlist,
                                       "summary.sig",
                                       metalink_url_string ? TRUE : FALSE,
+                                      n_network_retries,
                                       out_signatures,
                                       cancellable,
                                       error))
@@ -3056,6 +3106,7 @@ repo_remote_fetch_summary (OstreeRepo    *self,
                                           mirrorlist,
                                           "summary",
                                           metalink_url_string ? TRUE : FALSE,
+                                          n_network_retries,
                                           out_summary,
                                           cancellable,
                                           error))
@@ -3312,6 +3363,9 @@ initiate_request (OtPullData                 *pull_data,
  *   * update-frequency (u): Frequency to call the async progress callback in milliseconds, if any; only values higher than 0 are valid
  *   * localcache-repos (as): File paths for local repos to use as caches when doing remote fetches
  *   * append-user-agent (s): Additional string to append to the user agent
+ *   * n-network-retries (u): Number of times to retry each download on receiving
+ *     a transient network error, such as a socket timeout; default is 5, 0
+ *     means return errors without retrying
  */
 gboolean
 ostree_repo_pull_with_options (OstreeRepo             *self,
@@ -3345,6 +3399,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   gboolean opt_gpg_verify_set = FALSE;
   gboolean opt_gpg_verify_summary_set = FALSE;
   gboolean opt_collection_refs_set = FALSE;
+  gboolean opt_n_network_retries_set = FALSE;
   const char *main_collection_id = NULL;
   const char *url_override = NULL;
   gboolean inherit_transaction = FALSE;
@@ -3384,6 +3439,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
       (void) g_variant_lookup (options, "localcache-repos", "^a&s", &opt_localcache_repos);
       (void) g_variant_lookup (options, "timestamp-check", "b", &pull_data->timestamp_check);
       (void) g_variant_lookup (options, "append-user-agent", "s", &pull_data->append_user_agent);
+      opt_n_network_retries_set =
+        g_variant_lookup (options, "n-network-retries", "u", &pull_data->n_network_retries);
 
       if (pull_data->remote_refspec_name != NULL)
         pull_data->remote_name = g_strdup (pull_data->remote_refspec_name);
@@ -3423,6 +3480,9 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
     pull_data->async_error = NULL;
   pull_data->main_context = g_main_context_ref_thread_default ();
   pull_data->flags = flags;
+
+  if (!opt_n_network_retries_set)
+    pull_data->n_network_retries = DEFAULT_N_NETWORK_RETRIES;
 
   pull_data->repo = self;
   pull_data->progress = progress;
@@ -3569,6 +3629,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         {
           if (!fetch_mirrorlist (pull_data->fetcher,
                                  baseurl + strlen ("mirrorlist="),
+                                 pull_data->n_network_retries,
                                  &pull_data->meta_mirrorlist,
                                  cancellable, error))
             goto out;
@@ -3595,7 +3656,8 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         goto out;
 
       metalink = _ostree_metalink_new (pull_data->fetcher, "summary",
-                                       OSTREE_MAX_METADATA_SIZE, metalink_uri);
+                                       OSTREE_MAX_METADATA_SIZE, metalink_uri,
+                                       pull_data->n_network_retries);
 
       if (! _ostree_metalink_request_sync (metalink,
                                            &target_uri,
@@ -3641,6 +3703,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
           {
             if (!fetch_mirrorlist (pull_data->fetcher,
                                    contenturl + strlen ("mirrorlist="),
+                                   pull_data->n_network_retries,
                                    &pull_data->content_mirrorlist,
                                    cancellable, error))
               goto out;
@@ -3787,6 +3850,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         if (!_ostree_fetcher_mirrored_request_to_membuf (pull_data->fetcher,
                                                          pull_data->meta_mirrorlist,
                                                          "summary.sig", OSTREE_FETCHER_REQUEST_OPTIONAL_CONTENT,
+                                                         pull_data->n_network_retries,
                                                          &bytes_sig,
                                                          OSTREE_MAX_METADATA_SIZE,
                                                          cancellable, error))
@@ -3811,6 +3875,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
         if (!_ostree_fetcher_mirrored_request_to_membuf (pull_data->fetcher,
                                                          pull_data->meta_mirrorlist,
                                                          "summary", OSTREE_FETCHER_REQUEST_OPTIONAL_CONTENT,
+                                                         pull_data->n_network_retries,
                                                          &bytes_summary,
                                                          OSTREE_MAX_METADATA_SIZE,
                                                          cancellable, error))
@@ -4585,6 +4650,7 @@ typedef struct
   GVariant *options;
   OstreeAsyncProgress *progress;
   OstreeRepoFinder *default_finder_avahi;
+  guint n_network_retries;
 } FindRemotesData;
 
 static void
@@ -4604,7 +4670,8 @@ static FindRemotesData *
 find_remotes_data_new (const OstreeCollectionRef * const *refs,
                        GVariant                      *options,
                        OstreeAsyncProgress           *progress,
-                       OstreeRepoFinder              *default_finder_avahi)
+                       OstreeRepoFinder              *default_finder_avahi,
+                       guint                          n_network_retries)
 {
   g_autoptr(FindRemotesData) data = NULL;
 
@@ -4613,6 +4680,7 @@ find_remotes_data_new (const OstreeCollectionRef * const *refs,
   data->options = (options != NULL) ? g_variant_ref (options) : NULL;
   data->progress = (progress != NULL) ? g_object_ref (progress) : NULL;
   data->default_finder_avahi = (default_finder_avahi != NULL) ? g_object_ref (default_finder_avahi) : NULL;
+  data->n_network_retries = n_network_retries;
 
   return g_steal_pointer (&data);
 }
@@ -4692,6 +4760,9 @@ static void find_remotes_cb (GObject      *obj,
  *   * `override-commit-ids` (`as`): Array of specific commit IDs to fetch. The nth
  *   commit ID applies to the nth ref, so this must be the same length as @refs, if
  *   provided.
+ *   * `n-network-retries` (`u`): Number of times to retry each download on
+ *   receiving a transient network error, such as a socket timeout; default is
+ *   5, 0 means return errors without retrying.
  *
  * @finders must be a non-empty %NULL-terminated array of the #OstreeRepoFinder
  * instances to use, or %NULL to use the system default set of finders, which
@@ -4721,6 +4792,7 @@ ostree_repo_find_remotes_async (OstreeRepo                     *self,
   g_autoptr(OstreeRepoFinder) finder_mount = NULL;
   g_autoptr(OstreeRepoFinder) finder_avahi = NULL;
   g_autofree char **override_commit_ids = NULL;
+  guint n_network_retries = DEFAULT_N_NETWORK_RETRIES;
 
   g_return_if_fail (OSTREE_IS_REPO (self));
   g_return_if_fail (is_valid_collection_ref_array (refs));
@@ -4734,6 +4806,8 @@ ostree_repo_find_remotes_async (OstreeRepo                     *self,
     {
       (void) g_variant_lookup (options, "override-commit-ids", "^a&s", &override_commit_ids);
       g_return_if_fail (override_commit_ids == NULL || g_strv_length ((gchar **) refs) == g_strv_length (override_commit_ids));
+
+      (void) g_variant_lookup (options, "n-network-retries", "u", &n_network_retries);
     }
 
   /* Set up a task for the whole operation. */
@@ -4789,7 +4863,7 @@ ostree_repo_find_remotes_async (OstreeRepo                     *self,
   /* We need to keep a pointer to the default Avahi finder so we can stop it
    * again after the operation, which happens implicitly by dropping the final
    * ref. */
-  data = find_remotes_data_new (refs, options, progress, finder_avahi);
+  data = find_remotes_data_new (refs, options, progress, finder_avahi, n_network_retries);
   g_task_set_task_data (task, g_steal_pointer (&data), (GDestroyNotify) find_remotes_data_free);
 
   /* Asynchronously resolve all possible remotes for the given refs. */
@@ -5182,6 +5256,7 @@ find_remotes_cb (GObject      *obj,
                                                                mirrorlist,
                                                                commit_filename,
                                                                OSTREE_FETCHER_REQUEST_OPTIONAL_CONTENT,
+                                                               data->n_network_retries,
                                                                &commit_bytes,
                                                                0,  /* no maximum size */
                                                                cancellable,
@@ -5625,6 +5700,7 @@ ostree_repo_pull_from_remotes_async (OstreeRepo                           *self,
       copy_option (&options_dict, &local_options_dict, "subdirs", G_VARIANT_TYPE ("as"));
       copy_option (&options_dict, &local_options_dict, "update-frequency", G_VARIANT_TYPE ("u"));
       copy_option (&options_dict, &local_options_dict, "append-user-agent", G_VARIANT_TYPE ("s"));
+      copy_option (&options_dict, &local_options_dict, "n-network-retries", G_VARIANT_TYPE ("u"));
 
       local_options = g_variant_dict_end (&local_options_dict);
 
@@ -5849,6 +5925,9 @@ ostree_repo_resolve_keyring_for_collection (OstreeRepo    *self,
  * - override-url (s): Fetch summary from this URL if remote specifies no metalink in options
  * - http-headers (a(ss)): Additional headers to add to all HTTP requests
  * - append-user-agent (s): Additional string to append to the user agent
+ * - n-network-retries (u): Number of times to retry each download on receiving
+ *   a transient network error, such as a socket timeout; default is 5, 0
+ *   means return errors without retrying
  *
  * Returns: %TRUE on success, %FALSE on failure
  */

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -212,6 +212,7 @@ typedef struct {
   char *from_revision;
   char *to_revision;
   OstreeCollectionRef *requested_ref;  /* (nullable) */
+  guint n_retries_remaining;
 } FetchDeltaSuperData;
 
 static void
@@ -2656,8 +2657,10 @@ on_superblock_fetched (GObject   *src,
   if (local_error == NULL)
     pull_data->n_fetched_metadata++;
 
-  /* FIXME: This should check _ostree_fetcher_should_retry_request(). */
-  check_outstanding_requests_handle_error (pull_data, &local_error);
+  if (_ostree_fetcher_should_retry_request (local_error, fetch_data->n_retries_remaining--))
+    enqueue_one_static_delta_superblock_request_s (pull_data, g_steal_pointer (&fetch_data));
+  else
+    check_outstanding_requests_handle_error (pull_data, &local_error);
 
   g_clear_pointer (&fetch_data, fetch_delta_super_data_free);
 }
@@ -2711,6 +2714,7 @@ enqueue_one_static_delta_superblock_request (OtPullData                *pull_dat
   fdata->from_revision = g_strdup (from_revision);
   fdata->to_revision = g_strdup (to_revision);
   fdata->requested_ref = (ref != NULL) ? ostree_collection_ref_dup (ref) : NULL;
+  fdata->n_retries_remaining = pull_data->n_network_retries;
 
   enqueue_one_static_delta_superblock_request_s (pull_data, g_steal_pointer (&fdata));
 }

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2464,6 +2464,16 @@ typedef struct {
 } FetchDeltaSuperData;
 
 static void
+fetch_delta_super_data_free (FetchDeltaSuperData *fetch_data)
+{
+  g_free (fetch_data->from_revision);
+  g_free (fetch_data->to_revision);
+  if (fetch_data->requested_ref)
+    ostree_collection_ref_free (fetch_data->requested_ref);
+  g_free (fetch_data);
+}
+
+static void
 set_required_deltas_error (GError **error,
                            const char *from_revision,
                            const char *to_revision)
@@ -2543,15 +2553,12 @@ on_superblock_fetched (GObject   *src,
     }
 
  out:
-  g_free (fdata->from_revision);
-  g_free (fdata->to_revision);
-  if (fdata->requested_ref)
-    ostree_collection_ref_free (fdata->requested_ref);
-  g_free (fdata);
   g_assert (pull_data->n_outstanding_metadata_fetches > 0);
   pull_data->n_outstanding_metadata_fetches--;
   pull_data->n_fetched_metadata++;
   check_outstanding_requests_handle_error (pull_data, &local_error);
+
+  g_clear_pointer (&fetch_data, fetch_delta_super_data_free);
 }
 
 static gboolean

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1121,6 +1121,7 @@ content_fetch_on_complete (GObject        *object,
     }
 
  out:
+  g_assert (pull_data->n_outstanding_content_fetches > 0);
   pull_data->n_outstanding_content_fetches--;
 
   if (_ostree_fetcher_should_retry_request (local_error, fetch_data->n_retries_remaining--))
@@ -1170,6 +1171,7 @@ on_metadata_written (GObject           *object,
   queue_scan_one_metadata_object_c (pull_data, csum, objtype, fetch_data->path, 0, fetch_data->requested_ref);
 
  out:
+  g_assert (pull_data->n_outstanding_metadata_write_requests > 0);
   pull_data->n_outstanding_metadata_write_requests--;
   fetch_object_data_free (fetch_data);
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -215,6 +215,8 @@ static void queue_scan_one_metadata_object (OtPullData                *pull_data
                                             guint                      recursion_depth,
                                             const OstreeCollectionRef *ref);
 
+static void queue_scan_one_metadata_object_s (OtPullData                *pull_data,
+                                              ScanObjectQueueData       *scan_data);
 static void queue_scan_one_metadata_object_c (OtPullData                *pull_data,
                                               const guchar              *csum,
                                               OstreeObjectType           objtype,
@@ -1767,6 +1769,14 @@ queue_scan_one_metadata_object (OtPullData                *pull_data,
 }
 
 static void
+queue_scan_one_metadata_object_s (OtPullData          *pull_data,
+                                  ScanObjectQueueData *scan_data)
+{
+  g_queue_push_tail (&pull_data->scan_object_queue, scan_data);
+  ensure_idle_queued (pull_data);
+}
+
+static void
 queue_scan_one_metadata_object_c (OtPullData                *pull_data,
                                   const guchar              *csum,
                                   OstreeObjectType           objtype,
@@ -1782,8 +1792,7 @@ queue_scan_one_metadata_object_c (OtPullData                *pull_data,
   scan_data->recursion_depth = recursion_depth;
   scan_data->requested_ref = (ref != NULL) ? ostree_collection_ref_dup (ref) : NULL;
 
-  g_queue_push_tail (&pull_data->scan_object_queue, scan_data);
-  ensure_idle_queued (pull_data);
+  queue_scan_one_metadata_object_s (pull_data, g_steal_pointer (&scan_data));
 }
 
 /* Called out of the main loop to look at metadata objects which can have

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -224,6 +224,9 @@ static void queue_scan_one_metadata_object_c (OtPullData                *pull_da
                                               guint                      recursion_depth,
                                               const OstreeCollectionRef *ref);
 
+static void enqueue_one_object_request_s (OtPullData      *pull_data,
+                                          FetchObjectData *fetch_data);
+
 static gboolean scan_one_metadata_object (OtPullData                 *pull_data,
                                           const char                 *checksum,
                                           OstreeObjectType            objtype,
@@ -1919,31 +1922,14 @@ scan_one_metadata_object (OtPullData                 *pull_data,
 }
 
 static void
-enqueue_one_object_request (OtPullData                *pull_data,
-                            const char                *checksum,
-                            OstreeObjectType           objtype,
-                            const char                *path,
-                            gboolean                   is_detached_meta,
-                            gboolean                   object_is_stored,
-                            const OstreeCollectionRef *ref)
+enqueue_one_object_request_s (OtPullData      *pull_data,
+                              FetchObjectData *fetch_data)
 {
-  gboolean is_meta;
-  FetchObjectData *fetch_data;
+  const char *checksum;
+  OstreeObjectType objtype;
 
-  is_meta = OSTREE_OBJECT_TYPE_IS_META (objtype);
-
-  fetch_data = g_new0 (FetchObjectData, 1);
-  fetch_data->pull_data = pull_data;
-  fetch_data->object = ostree_object_name_serialize (checksum, objtype);
-  fetch_data->path = g_strdup (path);
-  fetch_data->is_detached_meta = is_detached_meta;
-  fetch_data->object_is_stored = object_is_stored;
-  fetch_data->requested_ref = (ref != NULL) ? ostree_collection_ref_dup (ref) : NULL;
-
-  if (is_meta)
-    pull_data->n_requested_metadata++;
-  else
-    pull_data->n_requested_content++;
+  ostree_object_name_deserialize (fetch_data->object, &checksum, &objtype);
+  gboolean is_meta = OSTREE_OBJECT_TYPE_IS_META (objtype);
 
   /* Are too many requests are in flight? */
   if (fetcher_queue_is_full (pull_data))
@@ -1965,6 +1951,35 @@ enqueue_one_object_request (OtPullData                *pull_data,
     {
       start_fetch (pull_data, fetch_data);
     }
+}
+
+static void
+enqueue_one_object_request (OtPullData                *pull_data,
+                            const char                *checksum,
+                            OstreeObjectType           objtype,
+                            const char                *path,
+                            gboolean                   is_detached_meta,
+                            gboolean                   object_is_stored,
+                            const OstreeCollectionRef *ref)
+{
+  FetchObjectData *fetch_data;
+
+  fetch_data = g_new0 (FetchObjectData, 1);
+  fetch_data->pull_data = pull_data;
+  fetch_data->object = ostree_object_name_serialize (checksum, objtype);
+  fetch_data->path = g_strdup (path);
+  fetch_data->is_detached_meta = is_detached_meta;
+  fetch_data->object_is_stored = object_is_stored;
+  fetch_data->requested_ref = (ref != NULL) ? ostree_collection_ref_dup (ref) : NULL;
+
+  gboolean is_meta = OSTREE_OBJECT_TYPE_IS_META (objtype);
+
+  if (is_meta)
+    pull_data->n_requested_metadata++;
+  else
+    pull_data->n_requested_content++;
+
+  enqueue_one_object_request_s (pull_data, g_steal_pointer (&fetch_data));
 }
 
 static void

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -127,6 +127,7 @@ typedef struct {
   GHashTable       *requested_fallback_content; /* Maps checksum to itself */
   GHashTable       *pending_fetch_metadata; /* Map<ObjectName,FetchObjectData> */
   GHashTable       *pending_fetch_content; /* Map<checksum,FetchObjectData> */
+  GHashTable       *pending_fetch_delta_superblocks; /* Set<FetchDeltaSuperData> */
   GHashTable       *pending_fetch_deltaparts; /* Set<FetchStaticDeltaData> */
   guint             n_outstanding_metadata_fetches;
   guint             n_outstanding_metadata_write_requests;
@@ -206,6 +207,13 @@ typedef struct {
   OstreeCollectionRef *requested_ref;  /* (nullable) */
 } ScanObjectQueueData;
 
+typedef struct {
+  OtPullData *pull_data;
+  char *from_revision;
+  char *to_revision;
+  OstreeCollectionRef *requested_ref;  /* (nullable) */
+} FetchDeltaSuperData;
+
 static void
 variant_or_null_unref (gpointer data)
 {
@@ -216,6 +224,8 @@ variant_or_null_unref (gpointer data)
 static void start_fetch (OtPullData *pull_data, FetchObjectData *fetch);
 static void start_fetch_deltapart (OtPullData *pull_data,
                                    FetchStaticDeltaData *fetch);
+static void start_fetch_delta_superblock (OtPullData          *pull_data,
+                                          FetchDeltaSuperData *fetch_data);
 static gboolean fetcher_queue_is_full (OtPullData *pull_data);
 static void queue_scan_one_metadata_object (OtPullData                *pull_data,
                                             const char                *csum,
@@ -235,6 +245,8 @@ static void queue_scan_one_metadata_object_c (OtPullData                *pull_da
 
 static void enqueue_one_object_request_s (OtPullData      *pull_data,
                                           FetchObjectData *fetch_data);
+static void enqueue_one_static_delta_superblock_request_s (OtPullData          *pull_data,
+                                                           FetchDeltaSuperData *fetch_data);
 static void enqueue_one_static_delta_part_request_s (OtPullData           *pull_data,
                                                      FetchStaticDeltaData *fetch_data);
 
@@ -393,6 +405,7 @@ check_outstanding_requests_handle_error (OtPullData          *pull_data,
       g_queue_foreach (&pull_data->scan_object_queue, (GFunc) scan_object_queue_data_free, NULL);
       g_queue_clear (&pull_data->scan_object_queue);
       g_hash_table_remove_all (pull_data->pending_fetch_metadata);
+      g_hash_table_remove_all (pull_data->pending_fetch_delta_superblocks);
       g_hash_table_remove_all (pull_data->pending_fetch_deltaparts);
       g_hash_table_remove_all (pull_data->pending_fetch_content);
     }
@@ -423,6 +436,16 @@ check_outstanding_requests_handle_error (OtPullData          *pull_data,
           start_fetch (pull_data, fetch);
           /* And unref the key */
           g_variant_unref (objname);
+        }
+
+      /* Next, process delta superblock requests */
+      g_hash_table_iter_init (&hiter, pull_data->pending_fetch_delta_superblocks);
+      while (!fetcher_queue_is_full (pull_data) &&
+             g_hash_table_iter_next (&hiter, &key, &value))
+        {
+          FetchDeltaSuperData *fetch = key;
+          g_hash_table_iter_steal (&hiter);
+          start_fetch_delta_superblock (pull_data, g_steal_pointer (&fetch));
         }
 
       /* Now, process deltapart requests */
@@ -2537,13 +2560,6 @@ get_best_static_delta_start_for (OtPullData *pull_data,
   return TRUE;
 }
 
-typedef struct {
-  OtPullData *pull_data;
-  char *from_revision;
-  char *to_revision;
-  OstreeCollectionRef *requested_ref;  /* (nullable) */
-} FetchDeltaSuperData;
-
 static void
 fetch_delta_super_data_free (FetchDeltaSuperData *fetch_data)
 {
@@ -2644,6 +2660,59 @@ on_superblock_fetched (GObject   *src,
   check_outstanding_requests_handle_error (pull_data, &local_error);
 
   g_clear_pointer (&fetch_data, fetch_delta_super_data_free);
+}
+
+static void
+start_fetch_delta_superblock (OtPullData          *pull_data,
+                              FetchDeltaSuperData *fetch_data)
+{
+  g_autofree char *delta_name =
+    _ostree_get_relative_static_delta_superblock_path (fetch_data->from_revision,
+                                                       fetch_data->to_revision);
+  _ostree_fetcher_request_to_membuf (pull_data->fetcher,
+                                     pull_data->content_mirrorlist,
+                                     delta_name, OSTREE_FETCHER_REQUEST_OPTIONAL_CONTENT,
+                                     OSTREE_MAX_METADATA_SIZE,
+                                     0, pull_data->cancellable,
+                                     on_superblock_fetched,
+                                     g_steal_pointer (&fetch_data));
+  pull_data->n_outstanding_metadata_fetches++;
+  pull_data->n_requested_metadata++;
+}
+
+static void
+enqueue_one_static_delta_superblock_request_s (OtPullData          *pull_data,
+                                               FetchDeltaSuperData *fetch_data)
+{
+  if (fetcher_queue_is_full (pull_data))
+    {
+      g_debug ("queuing fetch of static delta superblock %s-%s",
+               fetch_data->from_revision ?: "empty",
+               fetch_data->to_revision);
+
+      g_hash_table_add (pull_data->pending_fetch_delta_superblocks,
+                        g_steal_pointer (&fetch_data));
+    }
+  else
+    {
+      start_fetch_delta_superblock (pull_data, g_steal_pointer (&fetch_data));
+    }
+}
+
+/* Start a request for a static delta */
+static void
+enqueue_one_static_delta_superblock_request (OtPullData                *pull_data,
+                                             const char                *from_revision,
+                                             const char                *to_revision,
+                                             const OstreeCollectionRef *ref)
+{
+  FetchDeltaSuperData *fdata = g_new0(FetchDeltaSuperData, 1);
+  fdata->pull_data = pull_data;
+  fdata->from_revision = g_strdup (from_revision);
+  fdata->to_revision = g_strdup (to_revision);
+  fdata->requested_ref = (ref != NULL) ? ostree_collection_ref_dup (ref) : NULL;
+
+  enqueue_one_static_delta_superblock_request_s (pull_data, g_steal_pointer (&fdata));
 }
 
 static gboolean
@@ -3167,31 +3236,6 @@ reinitialize_fetcher (OtPullData *pull_data, const char *remote_name,
   return TRUE;
 }
 
-/* Start a request for a static delta */
-static void
-initiate_delta_request (OtPullData *pull_data,
-                        const char *from_revision,
-                        const char *to_revision,
-                        const OstreeCollectionRef *ref)
-{
-  g_autofree char *delta_name =
-    _ostree_get_relative_static_delta_superblock_path (from_revision, to_revision);
-  FetchDeltaSuperData *fdata = g_new0(FetchDeltaSuperData, 1);
-  fdata->pull_data = pull_data;
-  fdata->from_revision = g_strdup (from_revision);
-  fdata->to_revision = g_strdup (to_revision);
-  fdata->requested_ref = (ref != NULL) ? ostree_collection_ref_dup (ref) : NULL;
-
-  _ostree_fetcher_request_to_membuf (pull_data->fetcher,
-                                     pull_data->content_mirrorlist,
-                                     delta_name, OSTREE_FETCHER_REQUEST_OPTIONAL_CONTENT,
-                                     OSTREE_MAX_METADATA_SIZE,
-                                     0, pull_data->cancellable,
-                                     on_superblock_fetched, fdata);
-  pull_data->n_outstanding_metadata_fetches++;
-  pull_data->n_requested_metadata++;
-}
-
 /*
  * initiate_request:
  * @ref: Optional ref name and collection ID
@@ -3255,7 +3299,7 @@ initiate_request (OtPullData                 *pull_data,
           }
           break;
         case DELTA_SEARCH_RESULT_FROM:
-          initiate_delta_request (pull_data, deltares.from_revision, to_revision, ref);
+          enqueue_one_static_delta_superblock_request (pull_data, deltares.from_revision, to_revision, ref);
           break;
         case DELTA_SEARCH_RESULT_SCRATCH:
           {
@@ -3266,7 +3310,7 @@ initiate_request (OtPullData                 *pull_data,
             if (delta_from_revision != NULL)
               queue_scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT, NULL, 0, ref);
             else
-              initiate_delta_request (pull_data, NULL, to_revision, ref);
+              enqueue_one_static_delta_superblock_request (pull_data, NULL, to_revision, ref);
           }
           break;
         case DELTA_SEARCH_RESULT_UNCHANGED:
@@ -3312,14 +3356,14 @@ initiate_request (OtPullData                 *pull_data,
       if (delta_from_revision && g_str_equal (delta_from_revision, to_revision))
         queue_scan_one_metadata_object (pull_data, to_revision, OSTREE_OBJECT_TYPE_COMMIT, NULL, 0, ref);
       else
-        initiate_delta_request (pull_data, delta_from_revision ?: NULL, to_revision, ref);
+        enqueue_one_static_delta_superblock_request (pull_data, delta_from_revision ?: NULL, to_revision, ref);
     }
   else
     {
       /* Legacy path without a summary file - let's try a scratch delta, if that
        * doesn't work, it'll drop down to object requests.
        */
-      initiate_delta_request (pull_data, NULL, to_revision, NULL);
+      enqueue_one_static_delta_superblock_request (pull_data, NULL, to_revision, NULL);
     }
 
   return TRUE;
@@ -3519,6 +3563,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   pull_data->pending_fetch_metadata = g_hash_table_new_full (ostree_hash_object_name, g_variant_equal,
                                                              (GDestroyNotify)g_variant_unref,
                                                              (GDestroyNotify)fetch_object_data_free);
+  pull_data->pending_fetch_delta_superblocks = g_hash_table_new_full (NULL, NULL, (GDestroyNotify) fetch_delta_super_data_free, NULL);
   pull_data->pending_fetch_deltaparts = g_hash_table_new_full (NULL, NULL, (GDestroyNotify)fetch_static_delta_data_free, NULL);
 
   if (opt_localcache_repos && *opt_localcache_repos)
@@ -4482,6 +4527,7 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   g_clear_pointer (&pull_data->requested_metadata, (GDestroyNotify) g_hash_table_unref);
   g_clear_pointer (&pull_data->pending_fetch_content, (GDestroyNotify) g_hash_table_unref);
   g_clear_pointer (&pull_data->pending_fetch_metadata, (GDestroyNotify) g_hash_table_unref);
+  g_clear_pointer (&pull_data->pending_fetch_delta_superblocks, (GDestroyNotify) g_hash_table_unref);
   g_clear_pointer (&pull_data->pending_fetch_deltaparts, (GDestroyNotify) g_hash_table_unref);
   g_queue_foreach (&pull_data->scan_object_queue, (GFunc) scan_object_queue_data_free, NULL);
   g_queue_clear (&pull_data->scan_object_queue);


### PR DESCRIPTION
This is a straight backport of upstream’s:
 * https://github.com/ostreedev/ostree/pull/1599 (omitting [this commit](https://github.com/ostreedev/ostree/pull/1599/commits/b4ea90b89449a498d92b405e8629d3175a2b15cc) because it didn’t apply cleanly, but it’s just a code cleanup)
 * https://github.com/ostreedev/ostree/pull/1594
 * https://github.com/ostreedev/ostree/pull/1600 (not yet merged upstream; one merge conflict due to [this downstream patch](https://github.com/endlessm/ostree/commit/9ba58ef5c38cae1c0ebabefae8e3921d3e40d60d))