### PR TITLE
lib/repo-pull: Retry pulls without static deltas if they fail

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3417,13 +3417,13 @@ initiate_request (OtPullData                 *pull_data,
  *     a transient network error, such as a socket timeout; default is 5, 0
  *     means return errors without retrying
  */
-gboolean
-ostree_repo_pull_with_options (OstreeRepo             *self,
-                               const char             *remote_name_or_baseurl,
-                               GVariant               *options,
-                               OstreeAsyncProgress    *progress,
-                               GCancellable           *cancellable,
-                               GError                **error)
+static gboolean
+ostree_repo_pull_with_options_internal (OstreeRepo           *self,
+                                        const char           *remote_name_or_baseurl,
+                                        GVariant             *options,
+                                        OstreeAsyncProgress  *progress,
+                                        GCancellable         *cancellable,
+                                        GError              **error)
 {
   gboolean ret = FALSE;
   g_autoptr(GBytes) bytes_summary = NULL;
@@ -4539,6 +4539,50 @@ ostree_repo_pull_with_options (OstreeRepo             *self,
   g_clear_pointer (&pull_data->dirs, (GDestroyNotify) g_ptr_array_unref);
   g_clear_pointer (&remote_config, (GDestroyNotify) g_key_file_unref);
   return ret;
+}
+
+gboolean
+ostree_repo_pull_with_options (OstreeRepo             *self,
+                               const char             *remote_name_or_baseurl,
+                               GVariant               *options,
+                               OstreeAsyncProgress    *progress,
+                               GCancellable           *cancellable,
+                               GError                **error)
+{
+  g_autoptr(GError) local_error = NULL;
+
+  if (!ostree_repo_pull_with_options_internal (self, remote_name_or_baseurl,
+                                               options, progress, cancellable,
+                                               &local_error))
+    {
+      gboolean disable_static_deltas = FALSE, require_static_deltas = FALSE;
+
+      if (options != NULL)
+        {
+          g_variant_lookup (options, "disable-static-deltas", "b", &disable_static_deltas);
+          g_variant_lookup (options, "require-static-deltas", "b", &require_static_deltas);
+        }
+
+      if (g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND) &&
+          !disable_static_deltas && !require_static_deltas)
+        {
+          g_autoptr(GVariant) modified_options = NULL;
+          g_auto(GVariantDict) modified_options_dict;
+          g_variant_dict_init (&modified_options_dict, options);
+          g_variant_dict_insert (&modified_options_dict, "disable-static-deltas",
+                                 "b", TRUE);
+          modified_options = g_variant_dict_end (&modified_options_dict);
+
+          return ostree_repo_pull_with_options_internal (self, remote_name_or_baseurl,
+                                                         modified_options, progress,
+                                                         cancellable, error);
+        }
+
+      g_propagate_error (error, g_steal_pointer (&local_error));
+      return FALSE;
+    }
+
+  return TRUE;
 }
 
 #ifdef OSTREE_ENABLE_EXPERIMENTAL_API


### PR DESCRIPTION
If pulling a static delta fails (due to one part of it missing from a
mirror, for example), retry the entire pull operation with
disable-static-deltas=true.

This is a functional, but ugly approach to fixing the problem, and a
neater solution may be adopted upstream in future. If so, this commit
should be dropped and replaced with the upstream solution:

https://github.com/ostreedev/ostree/pull/1612

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T22873