### PR TITLE
lib/repo: Change default of core.add-remotes-config-dir to false

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -130,7 +130,7 @@ Boston, MA 02111-1307, USA.
           <para>
             Boolean value controlling whether new remotes will be added
             in the remotes configuration directory. Defaults to
-            <literal>true</literal> for system ostree repositories. When
+            <literal>false</literal> for all ostree repositories. When
             this is <literal>false</literal>, remotes will be added in
             the repository's <filename>config</filename> file.
           </para>

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -1571,8 +1571,8 @@ impl_repo_remote_add (OstreeRepo     *self,
   remote = ostree_remote_new (name);
 
   /* Only add repos in remotes.d if the repo option
-   * add-remotes-config-dir is true. This is the default for system
-   * repos.
+   * add-remotes-config-dir is true. This is the default for all repos (this
+   * is an Endless modification: see https://phabricator.endlessm.com/T22258).
    */
   g_autoptr(GFile) etc_ostree_remotes_d = get_remotes_d_dir (self, sysroot);
   if (etc_ostree_remotes_d && self->add_remotes_config_dir)
@@ -2816,14 +2816,18 @@ reload_core_config (OstreeRepo          *self,
         }
     }
 
-  /* By default, only add remotes in a remotes config directory for
-   * system repos. This is to preserve legacy behavior for non-system
-   * repos that specify a remotes config dir (flatpak).
+  /* By default, do not add remotes in a remotes config directory.
+   * This is an Endless modification which is necessary due to us using the
+   * same repository for the OS and the flatpak system repository — we do not
+   * want some remote config to end up in /etc/flatpak/remotes.d. We want it all
+   * in /ostree/repo/config.
+   *
+   * See: https://phabricator.endlessm.com/T22258
    */
-  { gboolean is_system = ostree_repo_is_system (self);
+  {
 
     if (!ot_keyfile_get_boolean_with_default (self->config, "core", "add-remotes-config-dir",
-                                              is_system, &self->add_remotes_config_dir, error))
+                                              FALSE, &self->add_remotes_config_dir, error))
       return FALSE;
   }
 

--- a/tests/admin-test.sh
+++ b/tests/admin-test.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-echo "1..$((23 + ${extra_admin_tests:-0}))"
+echo "1..$((24 + ${extra_admin_tests:-0}))"
 
 function validate_bootloader() {
     cd ${test_tmpdir};
@@ -298,8 +298,8 @@ echo "ok remote add physical sysroot"
 ln -sr sysroot ${deployment}/sysroot
 ln -s sysroot/ostree ${deployment}/ostree
 ${CMD_PREFIX} ostree --sysroot=${deployment} remote add --set=gpg-verify=false remote-test-nonphysical file://$(pwd)/testos-repo
-assert_not_file_has_content sysroot/ostree/repo/config remote-test-nonphysical
-assert_file_has_content ${deployment}/etc/ostree/remotes.d/remote-test-nonphysical.conf testos-repo
+assert_not_has_file ${deployment}/etc/ostree/remotes.d/remote-test-nonphysical.conf
+assert_file_has_content sysroot/ostree/repo/config remote-test-nonphysical
 echo "ok remote add nonphysical sysroot"
 
 # Test that setting add-remotes-config-dir to false adds a remote in the
@@ -310,6 +310,14 @@ ${CMD_PREFIX} ostree --sysroot=${deployment} remote add --set=gpg-verify=false r
 assert_not_has_file ${deployment}/etc/ostree/remotes.d/remote-test-config-dir.conf testos-repo
 assert_file_has_content sysroot/ostree/repo/config remote-test-config-dir
 echo "ok remote add nonphysical sysroot add-remotes-config-dir false"
+
+# And test that explicitly setting add-remotes-config-dir to true adds a remote
+# in the remotes config dir as with upstream OSTree.
+${CMD_PREFIX} ostree --repo=sysroot/ostree/repo config set core.add-remotes-config-dir true
+${CMD_PREFIX} ostree --sysroot=${deployment} remote add --set=gpg-verify=false remote-test-config-dir2 file://$(pwd)/testos-repo
+assert_file_has_content ${deployment}/etc/ostree/remotes.d/remote-test-config-dir2.conf testos-repo
+assert_not_file_has_content sysroot/ostree/repo/config remote-test-config-dir2
+echo "ok remote add nonphysical sysroot add-remotes-config-dir2 false"
 
 if env OSTREE_SYSROOT_DEBUG="${OSTREE_SYSROOT_DEBUG},test-fifreeze" \
        ${CMD_PREFIX} ostree admin deploy --os=testos testos:testos/buildmaster/x86_64-runtime 2>err.txt; then


### PR DESCRIPTION
In upstream OSTree, the default for core.add-remotes-config-dir is true
for system repositories and false for all other repositories. Since we
use the same repository for the OS and for flatpak, we need the
configuration value to be the same for both (otherwise there can be
conflicts between /etc/flatpak/remotes.d/*.conf and
/ostree/repo/config).

While we set core.add-remotes-config-dir=false in all our configurations
for OSTree, this patch exists for paranoia, as the consequences of using
the wrong default value for it are hard to recover from (essentially, a
non-updatable system).

See https://phabricator.endlessm.com/T22258.

This is a downstream patch which should not be upstreamed, and should
not be dropped from our fork of OSTree.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T22970