### PR TITLE
config: Add a core/change-update-summary option

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -94,6 +94,16 @@ Boston, MA 02111-1307, USA.
       </varlistentry>
 
       <varlistentry>
+        <term><varname>change-update-summary</varname></term>
+        <listitem><para>Boolean value controlling whether or not to
+        automatically update the summary file after any ref is added,
+        removed, or updated. This covers a superset of the cases covered by
+        commit-update-summary, with the exception of orphan commits which
+        shouldn't affect the summary anyway. Defaults to <literal>false</literal>.
+        </para></listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><varname>fsync</varname></term>
         <listitem><para>Boolean value controlling whether or not to
         ensure files are on stable storage when performing operations

--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -2385,6 +2385,12 @@ ostree_repo_commit_transaction (OstreeRepo                  *self,
       return FALSE;
   g_clear_pointer (&self->txn.collection_refs, g_hash_table_destroy);
 
+  /* Update the summary if change-update-summary is set, because doing so was
+   * delayed for each ref change during the transaction.
+   */
+  if (!_ostree_repo_maybe_regenerate_summary (self, cancellable, error))
+    return FALSE;
+
   self->in_transaction = FALSE;
 
   if (!ot_ensure_unlinked_at (self->repo_dir_fd, "transaction", 0))

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -437,6 +437,11 @@ _ostree_repo_get_remote_inherited (OstreeRepo  *self,
                                    const char  *name,
                                    GError     **error);
 
+gboolean
+_ostree_repo_maybe_regenerate_summary (OstreeRepo    *self,
+                                       GCancellable  *cancellable,
+                                       GError       **error);
+
 /* Locking APIs are currently private.
  * See https://github.com/ostreedev/ostree/pull/1555
  */

--- a/src/libostree/ostree-repo-refs.c
+++ b/src/libostree/ostree-repo-refs.c
@@ -1144,6 +1144,11 @@ _ostree_repo_write_ref (OstreeRepo                 *self,
   if (!_ostree_repo_update_mtime (self, error))
     return FALSE;
 
+  /* Update the summary after updating the mtime so the summary doesn't look
+   * out of date */
+  if (!self->in_transaction && !_ostree_repo_maybe_regenerate_summary (self, cancellable, error))
+    return FALSE;
+
   return TRUE;
 }
 

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5405,7 +5405,8 @@ summary_add_ref_entry (OstreeRepo       *self,
  * will aid clients in working out when to check for updates.
  *
  * It is regenerated automatically after a commit if
- * `core/commit-update-summary` is set.
+ * `core/commit-update-summary` is set, and automatically after any ref is
+ * added, removed, or updated if `core/change-update-summary` is set.
  *
  * If the `core/collection-id` key is set in the configuration, it will be
  * included as %OSTREE_SUMMARY_COLLECTION_ID in the summary file. Refs that
@@ -5606,6 +5607,28 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
     return FALSE;
 
   if (!ot_ensure_unlinked_at (self->repo_dir_fd, "summary.sig", error))
+    return FALSE;
+
+  return TRUE;
+}
+
+/* Regenerate the summary if `core/change-update-summary` is set */
+gboolean
+_ostree_repo_maybe_regenerate_summary (OstreeRepo    *self,
+                                       GCancellable  *cancellable,
+                                       GError       **error)
+{
+  gboolean update_summary;
+
+  if (!ot_keyfile_get_boolean_with_default (self->config, "core",
+                                            "change-update-summary", FALSE,
+                                            &update_summary, error))
+    return FALSE;
+
+  if (update_summary && !ostree_repo_regenerate_summary (self,
+                                                         NULL,
+                                                         cancellable,
+                                                         error))
     return FALSE;
 
   return TRUE;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5413,6 +5413,8 @@ summary_add_ref_entry (OstreeRepo       *self,
  * file, listed under the %OSTREE_SUMMARY_COLLECTION_MAP key. Collection IDs
  * and refs in %OSTREE_SUMMARY_COLLECTION_MAP are guaranteed to be in
  * lexicographic order.
+ *
+ * Locking: exclusive
  */
 gboolean
 ostree_repo_regenerate_summary (OstreeRepo     *self,
@@ -5420,6 +5422,18 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
                                 GCancellable   *cancellable,
                                 GError        **error)
 {
+  /* Take an exclusive lock. This makes sure the commits and deltas don't get
+   * deleted while generating the summary. It also means we can be sure refs
+   * won't be created/updated/deleted during the operation, without having to
+   * add exclusive locks to those operations which would prevent concurrent
+   * commits from working.
+   */
+  g_autoptr(OstreeRepoAutoLock) lock = NULL;
+  lock = _ostree_repo_auto_lock_push (self, OSTREE_REPO_LOCK_EXCLUSIVE,
+                                      cancellable, error);
+  if (!lock)
+    return FALSE;
+
   g_auto(GVariantDict) additional_metadata_builder = OT_VARIANT_BUILDER_INITIALIZER;
   g_variant_dict_init (&additional_metadata_builder, additional_metadata);
   g_autoptr(GVariantBuilder) refs_builder = g_variant_builder_new (G_VARIANT_TYPE ("a(s(taya{sv}))"));

--- a/tests/test-auto-summary.sh
+++ b/tests/test-auto-summary.sh
@@ -29,6 +29,7 @@ echo "1..4"
 setup_test_repository "bare"
 echo "ok setup"
 
+# Check that without commit-update-summary set, creating a commit doesn't update the summary
 mkdir test
 
 echo hello > test/a
@@ -47,6 +48,7 @@ echo "ok commit 2"
 
 assert_streq "$OLD_MD5" "$(md5sum repo/summary)"
 
+# Check that with commit-update-summary set, creating a commit updates the summary
 $OSTREE --repo=repo config set core.commit-update-summary true
 
 echo hello3 > test/a
@@ -56,7 +58,46 @@ echo "ok commit 3"
 
 assert_not_streq "$OLD_MD5" "$(md5sum repo/summary)"
 
+$OSTREE --repo=repo config set core.commit-update-summary false
+
 # Check that summary --update deletes the .sig file
 touch repo/summary.sig
 $OSTREE summary --update
 assert_not_has_file repo/summary.sig
+
+# Check that without change-update-summary set, adding, changing, or deleting a ref doesn't update the summary
+$OSTREE summary --update
+OLD_MD5=$(md5sum repo/summary)
+$OSTREE commit -b test2 -s "A commit" test
+
+assert_streq "$OLD_MD5" "$(md5sum repo/summary)"
+
+$OSTREE reset test test^
+
+assert_streq "$OLD_MD5" "$(md5sum repo/summary)"
+
+$OSTREE refs --delete test
+
+assert_streq "$OLD_MD5" "$(md5sum repo/summary)"
+
+# Check that with change-update-summary set, adding, changing, or deleting a ref updates the summary
+$OSTREE --repo=repo config set core.change-update-summary true
+
+$OSTREE summary --update
+OLD_MD5=$(md5sum repo/summary)
+echo hello > test/a
+$OSTREE commit -b test -s "A commit" test
+echo hello2 > test/a
+$OSTREE commit -b test -s "Another commit" test
+
+assert_not_streq "$OLD_MD5" "$(md5sum repo/summary)"
+
+OLD_MD5=$(md5sum repo/summary)
+$OSTREE reset test test^
+
+assert_not_streq "$OLD_MD5" "$(md5sum repo/summary)"
+
+OLD_MD5=$(md5sum repo/summary)
+$OSTREE refs --delete test
+
+assert_not_streq "$OLD_MD5" "$(md5sum repo/summary)"


### PR DESCRIPTION
This commits adds and implements a boolean repo config option called
"change-update-summary" which updates the summary file every time a ref
changes (additions, updates, and deletions).

The main impetus for this feature is that the `ostree create-usb` and
`flatpak create-usb` commands depend on the repo summary being up to
date. On the command line you can work around this by asking the user to
run `ostree summary --update` but in the case of GNOME Software calling
out to `flatpak create-usb` this wouldn't work because it's running as a
user and the repo is owned by root. That strategy also means flatpak
can't update the repo metadata refs for fear of invalidating the
summary.

Another use case for this relates to LAN updates. Specifically, the
component of eos-updater that generates DNS-SD records advertising ostree
refs depends on the repo summary being up to date.

Since ostree_repo_regenerate_summary() now takes an exclusive lock, this
should be safe to enable. However it's not enabled by default because of
the performance cost, and because it's more useful on clients than
servers (which likely have another mechanism for updating the summary).

Fixes https://github.com/ostreedev/ostree/issues/1664