### PR TITLE
lib/repo-pull: Use correct keyring for dynamic remotes

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -5316,8 +5316,9 @@ find_remotes_cb (GObject      *obj,
                                             summary_bytes, FALSE);
 
       /* Check the summary’s additional metadata and set up @commit_metadata
-       * and @refs_and_remotes_table with all the refs listed in the summary
-       * file which intersect with @refs. */
+       * and @refs_and_remotes_table with the refs listed in the summary file,
+       * filtered by the keyring associated with this result and the
+       * intersection with @refs. */
       additional_metadata_v = g_variant_get_child_value (summary_v, 1);
 
       if (g_variant_lookup (additional_metadata_v, OSTREE_SUMMARY_COLLECTION_ID, "s", &summary_collection_id))
@@ -5338,6 +5339,13 @@ find_remotes_cb (GObject      *obj,
       while (summary_collection_map != NULL &&
              g_variant_iter_loop (summary_collection_map, "{s@a(s(taya{sv}))}", &summary_collection_id, &summary_refs))
         {
+          /* Exclude refs that don't use the associated keyring if this is a
+           * dynamic remote, by comparing against the collection ID of the
+           * remote this one inherits from */
+          if (result->remote->refspec_name != NULL &&
+              !check_remote_matches_collection_id (self, result->remote->refspec_name, summary_collection_id))
+            continue;
+
           if (!find_remotes_process_refs (self, refs, result, i, summary_collection_id, summary_refs,
                                           commit_metadatas, refs_and_remotes_table))
             {


### PR DESCRIPTION
Normally, a configured remote will only serve refs with one associated
collection ID, but temporary remotes such as USB drives or LAN peers can
serve refs from multiple collection IDs which may use different GPG
keyrings. So the OstreeRepoFinderMount and OstreeRepoFinderAvahi classes
create dynamic OstreeRemote objects for each (uri, keyring) pair. So if
for example the USB mounted at /mnt/usb serves content from the
configured remotes "eos-apps" and "eos-sdk", the OstreeRepoFinderResult
array returned by ostree_repo_find_remotes_async() will have one result
with a remote called something like
file_mnt_usb_eos-apps.trustedkeys.gpg and the list of refs on the USB
that came from eos-apps, and another result with a remote
file_mnt_usb_eos-sdk.trustedkeys.gpg and the list of refs from eos-sdk.

Unfortunately while OstreeRepoFinderMount and OstreeRepoFinderAvahi
correctly only include refs in a result if the ref uses the associated
keyring, the find_remotes_cb() function used to clean up the set of
results looks at the remote summary file and includes every ref that's
in the intersection with the requested refs, regardless of whether it
uses a different remote's keyring. This leads to an error when you try
to pull from a USB containing refs from different collection IDs: the
pull using the wrong collection ID will error out with "Refspec not
found" and the result with the correct keyring will then be ignored "as
it has no relevant refs or they have already been pulled." So the pull
ultimately fails.

This commit fixes the issue by filtering refs coming from a dynamic
remote, so that only ones with the collection ID associated with the
keyring remote are examined. This only needs to be done for dynamic
remotes because you should be able to pull any ref from a configured
remote using its keyring. It's also only done when looking at the
collection map in the summary file, because LAN/USB remotes won't have a
"main" collection ID set (OSTREE_SUMMARY_COLLECTION_ID).