### PR TITLE
Add backported symbols to debian/libostree-1-1.symbols

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ostree (2018.6-3endless2) eos; urgency=medium
+
+  * Add backported symbols ostree_mutable_tree_remove and
+    ostree_repo_get_min_free_space_bytes to libostree-1-1.symbols.
+
+ -- Robert McQueen <rob@endlessm.com>  Thu, 20 Sep 2018 15:50:19 +0100
+
 ostree (2018.6-3endless1) master; urgency=medium
 
   * Resync Debian packaging changes (T23138):

--- a/debian/libostree-1-1.symbols
+++ b/debian/libostree-1-1.symbols
@@ -141,6 +141,7 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_mutable_tree_get_type@LIBOSTREE_2016.3 2016.4
  ostree_mutable_tree_lookup@LIBOSTREE_2016.3 2016.4
  ostree_mutable_tree_new@LIBOSTREE_2016.3 2016.4
+ ostree_mutable_tree_remove@LIBOSTREE_2018.9 2018.6-3endless2
  ostree_mutable_tree_replace_file@LIBOSTREE_2016.3 2016.4
  ostree_mutable_tree_set_contents_checksum@LIBOSTREE_2016.3 2016.4
  ostree_mutable_tree_set_metadata_checksum@LIBOSTREE_2016.3 2016.4


### PR DESCRIPTION
ostree_mutable_tree_remove and ostree_repo_get_min_free_space_bytes are
backported in Endless.

https://phabricator.endlessm.com/T23819