### PR TITLE
repo: Add OSTREE_REPO_PULL_FLAGS_DISABLE_MIN_FREE_SPACE flag

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -139,6 +139,7 @@ struct OstreeRepo {
   GError *writable_error;
   gboolean in_transaction;
   gboolean disable_fsync;
+  gboolean disable_min_free_space_check;
   gboolean disable_xattrs;
   guint zlib_compression_level;
   GHashTable *loose_object_devino_hash;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3600,6 +3600,7 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
 
   pull_data->is_mirror = (flags & OSTREE_REPO_PULL_FLAGS_MIRROR) > 0;
   pull_data->is_commit_only = (flags & OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY) > 0;
+  self->disable_min_free_space_check = (flags & OSTREE_REPO_PULL_FLAGS_DISABLE_MIN_FREE_SPACE) > 0;
   /* See our processing of OSTREE_REPO_PULL_FLAGS_UNTRUSTED below */
   if ((flags & OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES) > 0)
     pull_data->importflags |= _OSTREE_REPO_IMPORT_FLAGS_VERIFY_BAREUSERONLY;

--- a/src/libostree/ostree-repo.h
+++ b/src/libostree/ostree-repo.h
@@ -1223,6 +1223,7 @@ gboolean ostree_repo_prune_from_reachable (OstreeRepo             *self,
  * @OSTREE_REPO_PULL_FLAGS_UNTRUSTED: Do verify checksums of local (filesystem-accessible) repositories (defaults on for HTTP)
  * @OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES: Since 2017.7.  Reject writes of content objects with modes outside of 0775.
  * @OSTREE_REPO_PULL_FLAGS_TRUSTED_HTTP: Don't verify checksums of objects HTTP repositories (Since: 2017.12)
+ * @OSTREE_REPO_PULL_FLAGS_DISABLE_MIN_FREE_SPACE: Disables min_free_space-* check (Since 2018.x).
  */
 typedef enum {
   OSTREE_REPO_PULL_FLAGS_NONE,
@@ -1231,6 +1232,7 @@ typedef enum {
   OSTREE_REPO_PULL_FLAGS_UNTRUSTED = (1 << 2),
   OSTREE_REPO_PULL_FLAGS_BAREUSERONLY_FILES = (1 << 3),
   OSTREE_REPO_PULL_FLAGS_TRUSTED_HTTP = (1 << 4),
+  OSTREE_REPO_PULL_FLAGS_DISABLE_MIN_FREE_SPACE = (1 << 5)
 } OstreeRepoPullFlags;
 
 _OSTREE_PUBLIC


### PR DESCRIPTION
This disables the min-free-space-* check in pull operations.

https://phabricator.endlessm.com/T23758