### PR TITLE
create-usb: Always use archive mode

### DIFF
--- a/src/ostree/ot-builtin-create-usb.c
+++ b/src/ostree/ot-builtin-create-usb.c
@@ -102,21 +102,17 @@ ostree_builtin_create_usb (int            argc,
 
   /* Open the destination repository on the USB stick or create it if it doesn’t exist.
    * Check it’s below @mount_root_path, and that it’s not the same as the source
-   * repository.
-   *
-   * If the destination file system supports xattrs (for example, ext4), we use
-   * a BARE_USER repository; if it doesn’t (for example, FAT), we use ARCHIVE.
-   * In either case, we want a lossless repository. */
+   * repository. */
   const char *dest_repo_path = (opt_destination_repo != NULL) ? opt_destination_repo : ".ostree/repo";
 
   if (!glnx_shutil_mkdir_p_at (mount_root_dfd, dest_repo_path, 0755, cancellable, error))
     return FALSE;
 
-  OstreeRepoMode mode = OSTREE_REPO_MODE_BARE_USER;
-
-  if (TEMP_FAILURE_RETRY (fgetxattr (mount_root_dfd, "user.test", NULL, 0)) < 0 &&
-      (errno == ENOTSUP || errno == EOPNOTSUPP))
-    mode = OSTREE_REPO_MODE_ARCHIVE;
+  /* Always use the archive repo mode, which works on FAT file systems that
+   * don't support xattrs, compresses files to save space, doesn't store
+   * permission info directly in the file attributes, and is at least sometimes
+   * more performant than bare-user */
+  OstreeRepoMode mode = OSTREE_REPO_MODE_ARCHIVE;
 
   g_debug ("%s: Creating repository in mode %u", G_STRFUNC, mode);
 


### PR DESCRIPTION
Change the create-usb command so that it always creates the destination
repository using the "archive" mode, rather than using archive mode when
xattrs aren't supported and bare-user otherwise. This has a few
advantages:

1. The archive mode works with FAT filesystems, which is what most
USB drives are, and which doesn't support xattrs.

2. At least in some quick testing I did, archive mode is about
twice as performant as bare-user mode, in terms of how long it takes for
the create-usb command to complete.

3. This ensures that a tool can safely change the permissions on
".ostree/repo" and subdirectories after create-usb completes, which is
important for Endless since otherwise you can't use `ostree create-usb`
as root and then `flatpak create-usb` as a non-root user on the same USB
drive (or in other words copy OS updates and apps to the same USB).

Closes: #1733
Approved by: cgwalters