### PR TITLE
create-usb: Add a --commit option

### DIFF
--- a/man/ostree-create-usb.xml
+++ b/man/ostree-create-usb.xml
@@ -112,6 +112,15 @@ Boston, MA 02111-1307, USA.
                 </para></listitem>
             </varlistentry>
 
+            <varlistentry>
+                <term><option>--commit</option>=COMMIT</term>
+
+                <listitem><para>
+                  Pull COMMIT instead of whatever REF points to. This can only
+                  be used if a single ref is specified.
+                </para></listitem>
+            </varlistentry>
+
         </variablelist>
     </refsect1>
 

--- a/src/ostree/ot-builtin-create-usb.c
+++ b/src/ostree/ot-builtin-create-usb.c
@@ -33,11 +33,13 @@
 
 static gboolean opt_disable_fsync = FALSE;
 static char *opt_destination_repo = NULL;
+static char *opt_commit = NULL;
 
 static GOptionEntry options[] =
   {
     { "disable-fsync", 0, 0, G_OPTION_ARG_NONE, &opt_disable_fsync, "Do not invoke fsync()", NULL },
     { "destination-repo", 0, 0, G_OPTION_ARG_FILENAME, &opt_destination_repo, "Use custom repository directory within the mount", "DEST" },
+    { "commit", 0, 0, G_OPTION_ARG_STRING, &opt_commit, "Pull a specific commit (only works when a single ref is specified)", "COMMIT" },
     { NULL }
   };
 
@@ -75,6 +77,12 @@ ostree_builtin_create_usb (int            argc,
   if (argc % 2 == 1)
     {
       ot_util_usage_error (context, "Only complete COLLECTION-ID REF pairs may be specified", error);
+      return FALSE;
+    }
+
+  if (opt_commit && argc > 4)
+    {
+      ot_util_usage_error (context, "The --commit option can only be used when a single COLLECTION-ID REF pair is specified", error);
       return FALSE;
     }
 
@@ -158,7 +166,7 @@ ostree_builtin_create_usb (int            argc,
       const OstreeCollectionRef *ref = g_ptr_array_index (refs, i);
 
       g_variant_builder_add (&refs_builder, "(sss)",
-                             ref->collection_id, ref->ref_name, "");
+                             ref->collection_id, ref->ref_name, opt_commit ?: "");
     }
 
   {


### PR DESCRIPTION
Currently on Endless OS, the OSTree ref for the operating system is
something like os/eos/amd64/eos3, so that's what gets passed to `ostree
create-usb` when copying the OS to a USB drive (for offline updates).
However, when eos-updater checks for updates it pulls the metadata for a
candidate commit and in so doing updates that eos3 ref to point to the
partial commit being examined as a potential update rather than the
deployed commit. This causes `ostree create-usb` to fail with an error
like "No such metadata object
7fb045cb2d1f1f3a81bfc157c6128ff443eb56350315b9536bdb56aee0659863.dirtree".

OSTree creates deployment refs that look like "ostree/1/1/0" to maintain
a pointer to the deployed commit, but create-usb can't use these because
it shows up in the summary as just a ref, not a collection-ref.

So this commit adds a --commit option to the create-usb command, so we
can use the appropriate ref but copy the deployed commit rather than a
(potentially partial) update commit.

Closes: #1735
Approved by: cgwalters