### PR TITLE
lib/commit: Don't chown objects to repo target owner

### DIFF
--- a/src/libostree/ostree-repo-commit.c
+++ b/src/libostree/ostree-repo-commit.c
@@ -245,16 +245,7 @@ commit_loose_regfile_object (OstreeRepo        *self,
                              GCancellable      *cancellable,
                              GError           **error)
 {
-  /* We may be writing as root to a non-root-owned repository; if so,
-   * automatically inherit the non-root ownership.
-   */
-  if (self->mode == OSTREE_REPO_MODE_ARCHIVE
-      && self->target_owner_uid != -1)
-    {
-      if (fchown (tmpf->fd, self->target_owner_uid, self->target_owner_gid) < 0)
-        return glnx_throw_errno_prefix (error, "fchown");
-    }
-  else if (self->mode == OSTREE_REPO_MODE_BARE)
+  if (self->mode == OSTREE_REPO_MODE_BARE)
     {
       if (TEMP_FAILURE_RETRY (fchown (tmpf->fd, uid, gid)) < 0)
         return glnx_throw_errno_prefix (error, "fchown");

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -149,8 +149,6 @@ struct OstreeRepo {
   dev_t device;
   ino_t inode;
   uid_t owner_uid; /* Cache of repo's owner uid */
-  uid_t target_owner_uid; /* Ensure files are chowned to this uid/gid */
-  gid_t target_owner_gid;
   guint min_free_space_percent; /* See the min-free-space-percent config option */
   guint64 min_free_space_mb; /* See the min-free-space-size config option */
   guint64 reserved_blocks;

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3080,16 +3080,6 @@ ostree_repo_open (OstreeRepo    *self,
     return FALSE;
   self->owner_uid = stbuf.st_uid;
 
-  if (stbuf.st_uid != getuid () || stbuf.st_gid != getgid ())
-    {
-      self->target_owner_uid = stbuf.st_uid;
-      self->target_owner_gid = stbuf.st_gid;
-    }
-  else
-    {
-      self->target_owner_uid = self->target_owner_gid = -1;
-    }
-
   if (self->writable)
     {
       /* Always try to recreate the tmpdir to be nice to people


### PR DESCRIPTION
The idea is that if the process is running as root, it can change
ownership of newly written files to match the owner of the repo.
Unfortunately, it currently applies in the other direction, too - a
non-root user writing to a root owned repository. If the repo is
writable by the user but owned by root, it can still create files and
directories there, but it can't change ownership of them.

This feature comes from
https://bugzilla.gnome.org/show_bug.cgi?id=738954. As it turns out, this
feature was never completed. It only works on content objects and not
metadata objects, refs, deltas, summaries, etc. Rather than try to fix
all of those, remove the feature until someone has interest in
completing it.

Closes: #1754
Approved by: cgwalters