### PR TITLE
grub2: Disable use of grub-mkconfig on Endless

### DIFF
--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -77,6 +77,16 @@ _ostree_bootloader_grub2_query (OstreeBootloader *bootloader,
 {
   OstreeBootloaderGrub2 *self = OSTREE_BOOTLOADER_GRUB2 (bootloader);
 
+  /* FIXME: Endless specific patch: don't let libostree find our
+   * /boot/grub/grub.cfg because we manage that separately and disable
+   * grub-mkconfig. See:
+   * - https://phabricator.endlessm.com/T19614
+   * - https://phabricator.endlessm.com/T18848 */
+  {
+    *out_is_active = FALSE;
+    return TRUE;
+  }
+
   /* Look for the BIOS path first */
   if (g_file_query_exists (self->config_path_bios_1, NULL) ||
       g_file_query_exists (self->config_path_bios_2, NULL))


### PR DESCRIPTION
OSTree recently gained support[1] for recognizing the Debian-style
/boot/grub/grub.cfg path in addition to the existing support for the Red
Hat-style /boot/grub2/grub.cfg. With this, it decides to run
grub-mkconfig in ostree_sysroot_write_deployment_with_options() by
calling ostree_bootloader_write_config(). However grub-mkconfig is
disabled on Endless OS since the grub.cfg is hand-written and doesn't
need updates[2] and therefore returns a non-zero exit status. This
causes operations such as "ostree admin unlock --hotfix" and "ostree
admin upgrade" to fail.

So this commit effectively reverts the Debian grub support, by making
_ostree_bootloader_grub2_query() always return TRUE with out_is_active
set to FALSE, so that grub-mkconfig is not called and the operations
above succeed. In the longer term, Endless should migrate to letting
OSTree manage the grub config and drop this patch[3][4].

https://phabricator.endlessm.com/T25195

[1] https://github.com/ostreedev/ostree/commit/74bdf7e17
[2] https://phabricator.endlessm.com/T19614
[3] https://phabricator.endlessm.com/T14870
[4] https://phabricator.endlessm.com/T18848