### PR TITLE
Revert to version shipped in 3.5.4.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ostree (2018.6-3endless3) eos; urgency=medium
+
+  * Revert to version shipped in Endless OS 3.5.4.
+    https://phabricator.endlessm.com/T25195#674277
+
+ -- Will Thompson <wjt@endlessm.com>  Fri, 01 Feb 2019 06:48:17 +0000
+
 ostree (2018.6-3endless2) eos; urgency=medium
 
   * Add backported symbols ostree_mutable_tree_remove and


### PR DESCRIPTION
We are very close to release, and are scared of finding more regressions.

To revert to an older version of the package, we need a version number that compares newer than the newest version on the branch. We would then re-publish the new version as 2019.1-1endless2.

~ is special-cased in Debian versioning: normally XY > X for all non-empty Y, but X~Y < X for all Y.

**DO NOT MERGE** without further discussion. I am pushing this to test that Jenkins would generate a plausible-looking source package.

https://phabricator.endlessm.com/T25195#674277