### PR TITLE
Revert "Post-release bump"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,10 +4,10 @@ dnl update libostree-released.sym from libostree-devel.sym, and update the check
 dnl in test-symbols.sh, and also set is_release_build=yes below.  Then make
 dnl another post-release commit to bump the version, and set is_release_build=no.
 m4_define([year_version], [2019])
-m4_define([release_version], [2])
+m4_define([release_version], [1])
 m4_define([package_version], [year_version.release_version])
 AC_INIT([libostree], [package_version], [walters@verbum.org])
-is_release_build=no
+is_release_build=yes
 AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([buildutil])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
This reverts commit 40a54e3d273296c7aa8f2ea783a03bf55a80cbd4.

This commit reverts the version bump from 2019.1 to 2019.2 so that the
version of ostree in Endless reports to be 2019.1. This is more accurate
since 2019.2 hasn't been released yet. This was my fault since I rebased
onto upstream master rather than the 2019.1 release commit.

https://phabricator.endlessm.com/T25195