### PR TITLE
tests: Update for glib 2.59.2

### DIFF
--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -368,7 +368,7 @@ repo_init --no-gpg-verify
 ${CMD_PREFIX} ostree --repo=repo pull origin main@${prev_rev}
 ${CMD_PREFIX} ostree --repo=repo pull --dry-run --require-static-deltas origin ${delta_target} >dry-run-pull.txt
 # Compression can vary, so we support 400-699
-delta_dry_run_regexp='Delta update: 0/1 parts, 0 bytes/[456][0-9][0-9] bytes, 455 bytes total uncompressed'
+delta_dry_run_regexp='Delta update: 0/1 parts, 0[  ]bytes/[456][0-9][0-9][  ]bytes, 455[  ]bytes total uncompressed'
 assert_file_has_content dry-run-pull.txt "${delta_dry_run_regexp}"
 rev=$(${CMD_PREFIX} ostree --repo=repo rev-parse origin:main)
 assert_streq "${prev_rev}" "${rev}"

--- a/tests/pull-test2.sh
+++ b/tests/pull-test2.sh
@@ -55,7 +55,7 @@ ${CMD_PREFIX} ostree --repo=ostree-srv/repo static-delta generate ${remote_ref}
 ${CMD_PREFIX} ostree --repo=ostree-srv/repo summary -u
 ${CMD_PREFIX} ostree --repo=repo pull origin ${remote_ref}@${prev_rev}
 ${CMD_PREFIX} ostree --repo=repo pull --dry-run --require-static-deltas origin ${remote_ref} >dry-run-pull.txt
-assert_file_has_content dry-run-pull.txt 'Delta update: 0/1 parts, 0 bytes/[45][0-9].[0-9] kB, 1.[678] MB total uncompressed'
+assert_file_has_content dry-run-pull.txt 'Delta update: 0/1 parts, 0 bytes/[45][0-9].[0-9][  ]kB, 1.[678][  ]MB total uncompressed'
 ${CMD_PREFIX} ostree --repo=repo pull --require-static-deltas origin ${remote_ref}
 final_rev=$(${CMD_PREFIX} ostree --repo=repo rev-parse origin:${remote_ref})
 assert_streq "${rev}" "${final_rev}"


### PR DESCRIPTION
glib 2.59.2 uses a non-breaking space instead of a space to
separate the quantity and unit in g_format_size() so update
our test to handle both a plain space and a non-breaking space.

See https://gitlab.gnome.org/GNOME/glib/issues/1625

Closes: #1818
Approved by: cgwalters