### PR TITLE
Revert "Revert "lib/repo-pull: Disable LAN updates by default""

### DIFF
--- a/man/ostree.repo-config.xml
+++ b/man/ostree.repo-config.xml
@@ -232,8 +232,9 @@ Boston, MA 02111-1307, USA.
         of finders isn't explicitly specified, either by a consumer of
         libostree API or on the command line. Possible values:
         <literal>config</literal>, <literal>lan</literal>, and
-        <literal>mount</literal> (or any combination thereof). If
-        unset, this defaults to <literal>config;lan;mount;</literal>.
+        <literal>mount</literal> (or any combination thereof). If unset, this
+        defaults to <literal>config;mount;</literal> (since the LAN finder is
+        costly).
         </para></listitem>
       </varlistentry>
     </variablelist>

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -3103,7 +3103,7 @@ reload_core_config (OstreeRepo          *self,
 
     /* Fall back to a default set of finders */
     if (configured_finders == NULL)
-      configured_finders = g_strsplit ("config;lan;mount", ";", -1);
+      configured_finders = g_strsplit ("config;mount", ";", -1);
 
     g_clear_pointer (&self->repo_finders, g_strfreev);
     self->repo_finders = g_steal_pointer (&configured_finders);


### PR DESCRIPTION
This reverts commit 5233c3dc4686dd992e63c94c69e47fd6730acee8.

Disable LAN updates by default. See the ticket below for the rationale;
essentially this feature is not in a working state and carries a
significant performance cost. One can still enable LAN updates on a
specific computer; see the documentation for core.default-repo-finders
in ostree.repo-config(5).

https://phabricator.endlessm.com/T27862