### PR TITLE
prepare-root: Revert logging changes for rpm-ostree

### DIFF
--- a/Makefile-switchroot.am
+++ b/Makefile-switchroot.am
@@ -45,7 +45,7 @@ if BUILDOPT_USE_STATIC_COMPILER
 ostree_boot_SCRIPTS = ostree-prepare-root
 
 ostree-prepare-root : $(ostree_prepare_root_SOURCES)
-	$(STATIC_COMPILER) -o $@ -static $(top_srcdir)/src/switchroot/ostree-prepare-root.c $(ostree_prepare_root_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES) -DOSTREE_PREPARE_ROOT_STATIC=1
+	$(STATIC_COMPILER) -o $@ -static $(top_srcdir)/src/switchroot/ostree-prepare-root.c $(ostree_prepare_root_CPPFLAGS) $(AM_CFLAGS) $(DEFAULT_INCLUDES)
 else
 ostree_boot_PROGRAMS += ostree-prepare-root
 ostree_prepare_root_CFLAGS = $(AM_CFLAGS) -Isrc/switchroot
@@ -56,11 +56,6 @@ ostree_remount_SOURCES = \
     src/switchroot/ostree-remount.c \
     $(NULL)
 ostree_remount_CPPFLAGS = $(AM_CPPFLAGS) -Isrc/switchroot
-
-if BUILDOPT_SYSTEMD
-ostree_prepare_root_CPPFLAGS += -DHAVE_SYSTEMD=1
-ostree_prepare_root_LDADD = $(AM_LDFLAGS) $(LIBSYSTEMD_LIBS)
-endif
 
 # This is the "new mode" of using a generator for /var; see
 # https://github.com/ostreedev/ostree/issues/855

--- a/src/switchroot/ostree-prepare-root.c
+++ b/src/switchroot/ostree-prepare-root.c
@@ -47,15 +47,6 @@
 #include <errno.h>
 #include <ctype.h>
 
-#if defined(HAVE_LIBSYSTEMD) && !defined(OSTREE_PREPARE_ROOT_STATIC)
-#define USE_LIBSYSTEMD
-#endif
-
-#ifdef USE_LIBSYSTEMD
-#include <systemd/sd-journal.h>
-#define OSTREE_PREPARE_ROOT_DEPLOYMENT_MSG SD_ID128_MAKE(71,70,33,6a,73,ba,46,01,ba,d3,1a,f8,88,aa,0d,f7)
-#endif
-
 #include "ostree-mount-util.h"
 
 /* Initialized early in main */
@@ -80,19 +71,9 @@ resolve_deploy_path (const char * root_mountpoint)
   deploy_path = realpath (destpath, NULL);
   if (deploy_path == NULL)
     err (EXIT_FAILURE, "realpath(%s) failed", destpath);
-  if (stat (deploy_path, &stbuf) < 0)
-    err (EXIT_FAILURE, "stat(%s) failed", deploy_path);
   /* Quiet logs if there's no journal */
-#ifdef USE_LIBSYSTEMD
-  const char *resolved_path = deploy_path + strlen (root_mountpoint);
-  sd_journal_send ("MESSAGE=Resolved OSTree target to: %s", deploy_path,
-                   "MESSAGE_ID=" SD_ID128_FORMAT_STR,
-                   SD_ID128_FORMAT_VAL(OSTREE_PREPARE_ROOT_DEPLOYMENT_MSG),
-                   "DEPLOYMENT_PATH=%s", resolved_path,
-                   "DEPLOYMENT_DEVICE=%u", stbuf.st_dev,
-                   "DEPLOYMENT_INODE=%u", stbuf.st_ino,
-                   NULL);
-#endif
+  if (!running_as_pid1)
+    printf ("Resolved OSTree target to: %s\n", deploy_path);
   return deploy_path;
 }
 


### PR DESCRIPTION
This reverts the following commits:

304abee9eb "prepare-root: Fix compilation with --with-static-compiler"
298c601d88 "ostree-prepare-root: Log journal message after finding deployment"

Which were causing ostree-prepare-root to crash on the EC-100. We can
safely revert these since we don't use rpm-ostree.

https://phabricator.endlessm.com/T27976