### PR TITLE
libostree: Add ostree_async_progress_copy_state()

### DIFF
--- a/apidoc/ostree-sections.txt
+++ b/apidoc/ostree-sections.txt
@@ -3,6 +3,7 @@
 OstreeAsyncProgress
 ostree_async_progress_new
 ostree_async_progress_new_and_connect
+ostree_async_progress_copy_state
 ostree_async_progress_get_status
 ostree_async_progress_get
 ostree_async_progress_get_variant

--- a/src/libostree/libostree-released.sym
+++ b/src/libostree/libostree-released.sym
@@ -551,6 +551,7 @@ LIBOSTREE_2019.2 {
 
 LIBOSTREE_2019.3 {
 global:
+  ostree_async_progress_copy_state;
   ostree_repo_write_archive_to_mtree_from_fd;
   ostree_kernel_args_free;
   ostree_kernel_args_new;

--- a/src/libostree/ostree-async-progress.c
+++ b/src/libostree/ostree-async-progress.c
@@ -425,6 +425,42 @@ ostree_async_progress_set_uint64 (OstreeAsyncProgress       *self,
 }
 
 /**
+ * ostree_async_progress_copy_state:
+ * @self: An #OstreeAsyncProgress to copy from
+ * @dest: An #OstreeAsyncProgress to copy to
+ *
+ * Atomically copies all the state from @self to @dest, without invoking the
+ * callback.
+ * This is used for proxying progress objects across different #GMainContexts.
+ *
+ * Since: 2019.3
+ */
+void
+ostree_async_progress_copy_state (OstreeAsyncProgress *self,
+                                  OstreeAsyncProgress *dest)
+{
+  g_return_if_fail (OSTREE_IS_ASYNC_PROGRESS (self));
+  g_return_if_fail (OSTREE_IS_ASYNC_PROGRESS (dest));
+
+  g_mutex_lock (&self->lock);
+
+  if (self->dead)
+    goto out;
+
+  GLNX_HASH_TABLE_FOREACH_KV (self->values, void *, key, GVariant *, value)
+    {
+      if (value)
+        {
+          g_variant_ref (value);
+          g_hash_table_replace (dest->values, key, value);
+        }
+    }
+
+ out:
+  g_mutex_unlock (&self->lock);
+}
+
+/**
  * ostree_async_progress_new:
  *
  * Returns: (transfer full): A new progress object

--- a/src/libostree/ostree-async-progress.h
+++ b/src/libostree/ostree-async-progress.h
@@ -92,4 +92,8 @@ void ostree_async_progress_set_variant (OstreeAsyncProgress *self,
 _OSTREE_PUBLIC
 void ostree_async_progress_finish (OstreeAsyncProgress *self);
 
+_OSTREE_PUBLIC
+void ostree_async_progress_copy_state (OstreeAsyncProgress *self,
+                                       OstreeAsyncProgress *dest);
+
 G_END_DECLS

--- a/tests/test-symbols.sh
+++ b/tests/test-symbols.sh
@@ -54,7 +54,7 @@ echo 'ok documented symbols'
 
 # ONLY update this checksum in release commits!
 cat > released-sha256.txt <<EOF
-61829712341e3cbac76c472d67c500ed5ae2c7f315d90f5dbe3fd4382a250f17  ${released_syms}
+fa7528d32e9027c99d698adc25a7a266834abc810a04822963b2d693b475b9cd  ${released_syms}
 EOF
 sha256sum -c released-sha256.txt
 


### PR DESCRIPTION
This allows copying the state from one OstreeAsyncProgress object to
another, atomically, without invoking the callback. This is needed in
libflatpak, in order to chain OstreeAsyncProgress objects so that you
can still receive progress updates when iterating a different
GMainContext than the one that the OstreeAsyncProgress object was
created under.

https://phabricator.endlessm.com/T26965