### PR TITLE
Update libostree-1-1.symbols

### DIFF
--- a/debian/README.Endless
+++ b/debian/README.Endless
@@ -12,14 +12,8 @@ status of things.
 Ways in which the Endless package differs from Debian:
  1. We don’t use the full OSTree grub integration (etc/grub.d/15_ostree,
     usr/libexec/libostree/grub2-15_ostree). (See T18848.)
- 2. We carry some custom patches which change the repository format to
-    store extra data about commit sizes, which was used a long time ago in
-    the client update UI. (See T17367.)
- 3. We re-enable gjs build dependency as we have a way to install/test it
- 4. We bring back trivial-httpd subcommand
+ 2. We re-enable gjs build dependency as we have a way to install/test it
+ 3. We bring back trivial-httpd subcommand
 
-#1, #3 and #4 can be fixed at some point in the future (especially #3 and #4
-if debian decides to re-add the support).
-However #2 cannot be entirely fixed, since we will always need some
-compatibility code for generating the additional metadata on the server side.
-However, it could potentially be moved out of the OSTree package (T17367).
+These can be fixed at some point in the future (especially #2 and #3 if
+debian decides to re-add the support).

--- a/debian/libostree-1-1.symbols
+++ b/debian/libostree-1-1.symbols
@@ -30,6 +30,7 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  LIBOSTREE_2018.9@LIBOSTREE_2018.9 2018.9
  LIBOSTREE_2019.2@LIBOSTREE_2019.2 2019.2
  LIBOSTREE_2019.3@LIBOSTREE_2019.3 2019.3
+ ostree_async_progress_copy_state@LIBOSTREE_2019.3 2019.3
  ostree_async_progress_finish@LIBOSTREE_2016.3 2016.4
  ostree_async_progress_get@LIBOSTREE_2017.6 2017.6
  ostree_async_progress_get_status@LIBOSTREE_2016.3 2016.4

--- a/debian/libostree-1-1.symbols
+++ b/debian/libostree-1-1.symbols
@@ -30,6 +30,7 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  LIBOSTREE_2018.9@LIBOSTREE_2018.9 2018.9
  LIBOSTREE_2019.2@LIBOSTREE_2019.2 2019.2
  LIBOSTREE_2019.3@LIBOSTREE_2019.3 2019.3
+ LIBOSTREE_2019.7@LIBOSTREE_2019.7 2019.3
  ostree_async_progress_copy_state@LIBOSTREE_2019.3 2019.3
  ostree_async_progress_finish@LIBOSTREE_2016.3 2016.4
  ostree_async_progress_get@LIBOSTREE_2017.6 2017.6
@@ -88,8 +89,13 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_collection_ref_hash@LIBOSTREE_2018.6 2018.6
  ostree_collection_ref_new@LIBOSTREE_2018.6 2018.6
  ostree_commit_get_content_checksum@LIBOSTREE_2018.2 2018.2
+ ostree_commit_get_object_sizes@LIBOSTREE_2019.7 2019.3
  ostree_commit_get_parent@LIBOSTREE_2016.3 2016.4
  ostree_commit_get_timestamp@LIBOSTREE_2016.3 2016.4
+ ostree_commit_sizes_entry_copy@LIBOSTREE_2019.7 2019.3
+ ostree_commit_sizes_entry_free@LIBOSTREE_2019.7 2019.3
+ ostree_commit_sizes_entry_get_type@LIBOSTREE_2019.7 2019.3
+ ostree_commit_sizes_entry_new@LIBOSTREE_2019.7 2019.3
  ostree_content_file_parse@LIBOSTREE_2016.3 2016.4
  ostree_content_file_parse_at@LIBOSTREE_2016.3 2016.4
  ostree_content_stream_parse@LIBOSTREE_2016.3 2016.4

--- a/debian/libostree-1-1.symbols
+++ b/debian/libostree-1-1.symbols
@@ -265,7 +265,6 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_repo_fsck_object@LIBOSTREE_2017.15 2017.15
  ostree_repo_get_bootloader@LIBOSTREE_2019.2 2019.2
  ostree_repo_get_collection_id@LIBOSTREE_2018.6 2018.6
- ostree_repo_get_commit_sizes@LIBOSTREE_2016.3 2016.3
  ostree_repo_get_config@LIBOSTREE_2016.3 2016.4
  ostree_repo_get_default_repo_finders@LIBOSTREE_2018.9 2018.9
  ostree_repo_get_dfd@LIBOSTREE_2016.4 2016.4


### PR DESCRIPTION
Update the debian symbols file for libostree-1-1 with the APIs we've backported and the now removed `ostree_repo_get_commit_sizes`. This is the packaging companion to #164. As noted there, eos-updater will need to be rebuilt after this is merged and built. However, since symbol version `LIBOSTREE_2019.7` was used for the new symbols, it won't need to be rebuilt again after we rebase on 2019.7.

https://phabricator.endlessm.com/T18171