### PR TITLE
Revert "deploy: support devicetree directory"

### DIFF
--- a/src/libostree/ostree-bootloader-uboot.c
+++ b/src/libostree/ostree-bootloader-uboot.c
@@ -144,10 +144,6 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot     *self,
       if (val)
         g_ptr_array_add (new_lines, g_strdup_printf ("fdt_file%s=%s", index_suffix, val));
 
-      val = ostree_bootconfig_parser_get (config, "devicetreepath");
-      if (val)
-        g_ptr_array_add (new_lines, g_strdup_printf ("fdt_path%s=%s", index_suffix, val));
-
       val = ostree_bootconfig_parser_get (config, "options");
       if (val)
         {


### PR DESCRIPTION
This reverts commit 61c50925fb9218f94562ef07e26c2c1a8b978ba1.

The main purpose of T29416 is test the commit provided by upstream. And,
we have the test result and gave feedback. Besides, it does not meet the
criteria we expected which provides dtb folder with the same structure
as the way device tree binaries get installed by the official Linux
kernel. We have already fed back the idea to upstream [1]. So, it is the
time to revert the commit ("deploy: support devicetree directory").

https://phabricator.endlessm.com/T29416

[1] https://github.com/ostreedev/ostree/pull/2001#issuecomment-605816752