### PR TITLE
dracut: Create reproducible images

### DIFF
--- a/src/boot/dracut/ostree.conf
+++ b/src/boot/dracut/ostree.conf
@@ -16,3 +16,4 @@
 # Boston, MA 02111-1307, USA.
 
 add_dracutmodules+=" ostree systemd "
+reproducible=yes


### PR DESCRIPTION
Without reproducible images, a rebuild of the initrd will create a
different image file (due to things like creation time of the files in
the cpio archive) even if the actual contents in it are exactly the
same, adding an unnecessary download during updates.

Adding 'reproducible=yes' avoids this and creates the same image files
for the same content.

https://phabricator.endlessm.com/T30443