### PR TITLE
T30404 Backport latency fixes

### DIFF
--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -50,6 +50,8 @@ G_BEGIN_DECLS
 #define OSTREE_SUMMARY_EXPIRES "ostree.summary.expires"
 #define OSTREE_SUMMARY_COLLECTION_ID "ostree.summary.collection-id"
 #define OSTREE_SUMMARY_COLLECTION_MAP "ostree.summary.collection-map"
+#define OSTREE_SUMMARY_MODE "ostree.summary.mode"
+#define OSTREE_SUMMARY_TOMBSTONE_COMMITS "ostree.summary.tombstone-commits"
 
 #define _OSTREE_PAYLOAD_LINK_PREFIX "../"
 #define _OSTREE_PAYLOAD_LINK_PREFIX_LEN (sizeof (_OSTREE_PAYLOAD_LINK_PREFIX) - 1)

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2239,6 +2239,8 @@ start_fetch (OtPullData *pull_data,
                                       is_meta ? meta_fetch_on_complete : content_fetch_on_complete, fetch);
 }
 
+/* Deprecated: code should load options from the `summary` file rather than
+ * downloading the remote’s `config` file, to save on network round trips. */
 static gboolean
 load_remote_repo_config (OtPullData    *pull_data,
                          GKeyFile     **out_keyfile,
@@ -3972,30 +3974,6 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
       if (!ostree_repo_open (pull_data->remote_repo_local, cancellable, error))
         goto out;
     }
-  else
-    {
-      if (!load_remote_repo_config (pull_data, &remote_config, cancellable, error))
-        goto out;
-
-      if (!ot_keyfile_get_value_with_default (remote_config, "core", "mode", "bare",
-                                              &remote_mode_str, error))
-        goto out;
-
-      if (!ostree_repo_mode_from_string (remote_mode_str, &pull_data->remote_mode, error))
-        goto out;
-
-      if (!ot_keyfile_get_boolean_with_default (remote_config, "core", "tombstone-commits", FALSE,
-                                                &pull_data->has_tombstone_commits, error))
-        goto out;
-
-      if (pull_data->remote_mode != OSTREE_REPO_MODE_ARCHIVE)
-        {
-          g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-                       "Can't pull from archives with mode \"%s\"",
-                       remote_mode_str);
-          goto out;
-        }
-    }
   }
 
   /* Change some option defaults if we're actually pulling from a local
@@ -4069,6 +4047,8 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
     g_autoptr(GVariant) deltas = NULL;
     g_autoptr(GVariant) additional_metadata = NULL;
     gboolean summary_from_cache = FALSE;
+    gboolean remote_mode_loaded = FALSE;
+    gboolean tombstone_commits = FALSE;
 
     if (summary_sig_bytes_v)
       {
@@ -4322,6 +4302,46 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
                                  g_strdup (delta),
                                  csum_data);
           }
+      }
+
+    if (pull_data->summary &&
+        g_variant_lookup (additional_metadata, OSTREE_SUMMARY_MODE, "s", &remote_mode_str) &&
+        g_variant_lookup (additional_metadata, OSTREE_SUMMARY_TOMBSTONE_COMMITS, "b", &tombstone_commits))
+      {
+        if (!ostree_repo_mode_from_string (remote_mode_str, &pull_data->remote_mode, error))
+          goto out;
+        pull_data->has_tombstone_commits = tombstone_commits;
+        remote_mode_loaded = TRUE;
+      }
+    else if (pull_data->remote_repo_local == NULL)
+      {
+        /* Fall-back path which loads the necessary config from the remote’s
+         * `config` file. Doing so is deprecated since it means an
+         * additional round trip to the remote for each pull. No need to do
+         * it for local pulls. */
+        if (!load_remote_repo_config (pull_data, &remote_config, cancellable, error))
+          goto out;
+
+        if (!ot_keyfile_get_value_with_default (remote_config, "core", "mode", "bare",
+                                                &remote_mode_str, error))
+          goto out;
+
+        if (!ostree_repo_mode_from_string (remote_mode_str, &pull_data->remote_mode, error))
+          goto out;
+
+        if (!ot_keyfile_get_boolean_with_default (remote_config, "core", "tombstone-commits", FALSE,
+                                                  &pull_data->has_tombstone_commits, error))
+          goto out;
+
+        remote_mode_loaded = TRUE;
+      }
+
+    if (remote_mode_loaded && pull_data->remote_repo_local == NULL && pull_data->remote_mode != OSTREE_REPO_MODE_ARCHIVE)
+      {
+        g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                     "Can't pull from archives with mode \"%s\"",
+                     remote_mode_str);
+        goto out;
       }
   }
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3547,6 +3547,14 @@ initiate_request (OtPullData                 *pull_data,
  *     not being pulled will be ignored and any ref without a keyring remote
  *     will be verified with the keyring of the remote being pulled from.
  *     Since: 2019.2
+ *   * `summary-bytes` (`ay'): Contents of the `summary` file to use. If this is
+ *     specified, `summary-sig-bytes` must also be specified. This is
+ *     useful if doing multiple pull operations in a transaction, using
+ *     ostree_repo_remote_fetch_summary_with_options() beforehand to download
+ *     the `summary` and `summary.sig` once for the entire transaction. If not
+ *     specified, the `summary` will be downloaded from the remote. Since: 2020.5
+ *   * `summary-sig-bytes` (`ay`): Contents of the `summary.sig` file. If this
+ *     is specified, `summary-bytes` must also be specified. Since: 2020.5
  */
 static gboolean
 ostree_repo_pull_with_options_internal (OstreeRepo           *self,
@@ -3589,6 +3597,8 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
   int i;
   g_autofree char **opt_localcache_repos = NULL;
   g_autoptr(GVariantIter) ref_keyring_map_iter = NULL;
+  g_autoptr(GVariant) summary_bytes_v = NULL;
+  g_autoptr(GVariant) summary_sig_bytes_v = NULL;
   /* If refs or collection-refs has exactly one value, this will point to that
    * value, otherwise NULL. Used for logging.
    */
@@ -3630,6 +3640,8 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
         g_variant_lookup (options, "n-network-retries", "u", &pull_data->n_network_retries);
       opt_ref_keyring_map_set =
 	g_variant_lookup (options, "ref-keyring-map", "a(sss)", &ref_keyring_map_iter);
+      (void) g_variant_lookup (options, "summary-bytes", "@ay", &summary_bytes_v);
+      (void) g_variant_lookup (options, "summary-sig-bytes", "@ay", &summary_sig_bytes_v);
 
       if (pull_data->remote_refspec_name != NULL)
         pull_data->remote_name = g_strdup (pull_data->remote_refspec_name);
@@ -3666,6 +3678,10 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
    * in-advance information for bare fetches.
    */
   g_return_val_if_fail (!pull_data->dry_run || pull_data->require_static_deltas, FALSE);
+
+  /* summary-bytes and summary-sig-bytes must both be specified, or neither be
+   * specified, so we know they’re consistent */
+  g_return_val_if_fail ((summary_bytes_v == NULL) == (summary_sig_bytes_v == NULL), FALSE);
 
   pull_data->is_mirror = (flags & OSTREE_REPO_PULL_FLAGS_MIRROR) > 0;
   pull_data->is_commit_only = (flags & OSTREE_REPO_PULL_FLAGS_COMMIT_ONLY) > 0;
@@ -3860,6 +3876,10 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
       if (!metalink_uri)
         goto out;
 
+      /* FIXME: Use summary_bytes_v/summary_sig_bytes_v to avoid unnecessary
+       * re-downloads here. Would require additional support for caching the
+       * metalink file or mirror list. */
+
       metalink = _ostree_metalink_new (pull_data->fetcher, "summary",
                                        OSTREE_MAX_METADATA_SIZE, metalink_uri,
                                        pull_data->n_network_retries);
@@ -4050,7 +4070,25 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
     g_autoptr(GVariant) additional_metadata = NULL;
     gboolean summary_from_cache = FALSE;
 
-    if (!pull_data->summary_data_sig)
+    if (summary_sig_bytes_v)
+      {
+        /* Must both be specified */
+        g_assert (summary_bytes_v);
+
+        bytes_sig = g_variant_get_data_as_bytes (summary_sig_bytes_v);
+        bytes_summary = g_variant_get_data_as_bytes (summary_bytes_v);
+
+        if (!bytes_sig || !bytes_summary)
+          {
+            g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                         "summary-bytes or summary-sig-bytes set to invalid value");
+            goto out;
+          }
+
+        g_debug ("Loaded %s summary from options", remote_name_or_baseurl);
+      }
+
+    if (!bytes_sig)
       {
         if (!_ostree_fetcher_mirrored_request_to_membuf (pull_data->fetcher,
                                                          pull_data->meta_mirrorlist,
@@ -4063,6 +4101,7 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
       }
 
     if (bytes_sig &&
+        !bytes_summary &&
         !pull_data->remote_repo_local &&
         !_ostree_repo_load_cache_summary_if_same_sig (self,
                                                       remote_name_or_baseurl,
@@ -4072,7 +4111,7 @@ ostree_repo_pull_with_options_internal (OstreeRepo           *self,
                                                       error))
       goto out;
 
-    if (bytes_summary)
+    if (bytes_summary && !summary_bytes_v)
       {
         g_debug ("Loaded %s summary from cache", remote_name_or_baseurl);
         summary_from_cache = TRUE;

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -3512,33 +3512,34 @@ initiate_request (OtPullData                 *pull_data,
  * Like ostree_repo_pull(), but supports an extensible set of flags.
  * The following are currently defined:
  *
- *   * refs (as): Array of string refs
- *   * collection-refs (a(sss)): Array of (collection ID, ref name, checksum) tuples to pull;
+ *   * `refs` (`as`): Array of string refs
+ *   * `collection-refs` (`a(sss)`): Array of (collection ID, ref name, checksum) tuples to pull;
  *     mutually exclusive with `refs` and `override-commit-ids`. Checksums may be the empty
  *     string to pull the latest commit for that ref
- *   * flags (i): An instance of #OstreeRepoPullFlags
- *   * subdir (s): Pull just this subdirectory
- *   * subdirs (as): Pull just these subdirectories
- *   * override-remote-name (s): If local, add this remote to refspec
- *   * gpg-verify (b): GPG verify commits
- *   * gpg-verify-summary (b): GPG verify summary
- *   * depth (i): How far in the history to traverse; default is 0, -1 means infinite
- *   * disable-static-deltas (b): Do not use static deltas
- *   * require-static-deltas (b): Require static deltas
- *   * override-commit-ids (as): Array of specific commit IDs to fetch for refs
- *   * timestamp-check (b): Verify commit timestamps are newer than current (when pulling via ref); Since: 2017.11
- *   * metadata-size-restriction (t): Restrict metadata objects to a maximum number of bytes; 0 to disable.  Since: 2018.9
- *   * dry-run (b): Only print information on what will be downloaded (requires static deltas)
- *   * override-url (s): Fetch objects from this URL if remote specifies no metalink in options
- *   * inherit-transaction (b): Don't initiate, finish or abort a transaction, useful to do multiple pulls in one transaction.
- *   * http-headers (a(ss)): Additional headers to add to all HTTP requests
- *   * update-frequency (u): Frequency to call the async progress callback in milliseconds, if any; only values higher than 0 are valid
- *   * localcache-repos (as): File paths for local repos to use as caches when doing remote fetches
- *   * append-user-agent (s): Additional string to append to the user agent
- *   * n-network-retries (u): Number of times to retry each download on receiving
+ *   * `flags` (`i`): An instance of #OstreeRepoPullFlags
+ *   * `subdir` (`s`): Pull just this subdirectory
+ *   * `subdirs` (`as`): Pull just these subdirectories
+ *   * `override-remote-name` (`s`): If local, add this remote to refspec
+ *   * `gpg-verify` (`b`): GPG verify commits
+ *   * `gpg-verify-summary` (`b`): GPG verify summary
+ *   * `depth` (`i`): How far in the history to traverse; default is 0, -1 means infinite
+ *   * `per-object-fsync` (`b`): Perform disk writes more slowly, avoiding a single large I/O sync
+ *   * `disable-static-deltas` (`b`): Do not use static deltas
+ *   * `require-static-deltas` (`b`): Require static deltas
+ *   * `override-commit-ids` (`as`): Array of specific commit IDs to fetch for refs
+ *   * `timestamp-check` (`b`): Verify commit timestamps are newer than current (when pulling via ref); Since: 2017.11
+ *   * `metadata-size-restriction` (`t`): Restrict metadata objects to a maximum number of bytes; 0 to disable.  Since: 2018.9
+ *   * `dry-run` (`b`): Only print information on what will be downloaded (requires static deltas)
+ *   * `override-url` (`s`): Fetch objects from this URL if remote specifies no metalink in options
+ *   * `inherit-transaction` (`b`): Don't initiate, finish or abort a transaction, useful to do multiple pulls in one transaction.
+ *   * `http-headers` (`a(ss)`): Additional headers to add to all HTTP requests
+ *   * `update-frequency` (`u`): Frequency to call the async progress callback in milliseconds, if any; only values higher than 0 are valid
+ *   * `localcache-repos` (`as`): File paths for local repos to use as caches when doing remote fetches
+ *   * `append-user-agent` (`s`): Additional string to append to the user agent
+ *   * `n-network-retries` (`u`): Number of times to retry each download on receiving
  *     a transient network error, such as a socket timeout; default is 5, 0
  *     means return errors without retrying. Since: 2018.6
- *   * ref-keyring-map (a(sss)): Array of (collection ID, ref name, keyring
+ *   * `ref-keyring-map` (`a(sss)`): Array of (collection ID, ref name, keyring
  *     remote name) tuples specifying which remote's keyring should be used when
  *     doing GPG verification of each collection-ref. This is useful to prevent a
  *     remote from serving malicious updates to refs which did not originate from

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -5833,6 +5833,24 @@ ostree_repo_regenerate_summary (OstreeRepo     *self,
                                  g_variant_new_uint64 (GUINT64_TO_BE (g_get_real_time () / G_USEC_PER_SEC)));
   }
 
+  {
+    g_autofree char *remote_mode_str = NULL;
+    if (!ot_keyfile_get_value_with_default (self->config, "core", "mode", "bare",
+                                            &remote_mode_str, error))
+      return FALSE;
+    g_variant_dict_insert_value (&additional_metadata_builder, OSTREE_SUMMARY_MODE,
+                                 g_variant_new_string (remote_mode_str));
+  }
+
+  {
+    gboolean tombstone_commits = FALSE;
+    if (!ot_keyfile_get_boolean_with_default (self->config, "core", "tombstone-commits", FALSE,
+                                              &tombstone_commits, error))
+      return FALSE;
+    g_variant_dict_insert_value (&additional_metadata_builder, OSTREE_SUMMARY_TOMBSTONE_COMMITS,
+                                 g_variant_new_boolean (tombstone_commits));
+  }
+
   /* Add refs which have a collection specified, which could be in refs/mirrors,
    * refs/heads, and/or refs/remotes. */
   {

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -351,6 +351,22 @@ ot_dump_summary_bytes (GBytes          *summary_bytes,
           pretty_key = "Collection Map";
           value_str = g_strdup ("(printed above)");
         }
+      else if (g_strcmp0 (key, OSTREE_SUMMARY_MODE) == 0)
+        {
+          OstreeRepoMode repo_mode;
+          const char *repo_mode_str = g_variant_get_string (value, NULL);
+
+          pretty_key = "Repository Mode";
+          if (!ostree_repo_mode_from_string (repo_mode_str, &repo_mode, NULL))
+            value_str = g_strdup_printf ("Invalid (‘%s’)", repo_mode_str);
+          else
+            value_str = g_strdup (repo_mode_str);
+        }
+      else if (g_strcmp0 (key, OSTREE_SUMMARY_TOMBSTONE_COMMITS) == 0)
+        {
+          pretty_key = "Has Tombstone Commits";
+          value_str = g_strdup (g_variant_get_boolean (value) ? "Yes" : "No");
+        }
       else
         {
           value_str = g_variant_print (value, FALSE);

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -312,10 +312,11 @@ ot_dump_summary_bytes (GBytes          *summary_bytes,
   collection_map = g_variant_lookup_value (exts, OSTREE_SUMMARY_COLLECTION_MAP, G_VARIANT_TYPE ("a{sa(s(taya{sv}))}"));
   if (collection_map != NULL)
     {
+      g_autoptr(GVariant) collection_refs = NULL;
       g_variant_iter_init (&iter, collection_map);
 
-      while (g_variant_iter_loop (&iter, "{&s@a(s(taya{sv}))}", &collection_id, &refs))
-        dump_summary_refs (collection_id, refs);
+      while (g_variant_iter_loop (&iter, "{&s@a(s(taya{sv}))}", &collection_id, &collection_refs))
+        dump_summary_refs (collection_id, collection_refs);
     }
 
   /* Print out the additional metadata. */

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -64,5 +64,5 @@ echo "ok view summary"
 ${OSTREE} summary --raw > raw-summary.txt
 assert_file_has_content_literal raw-summary.txt "('main', ("
 assert_file_has_content_literal raw-summary.txt "('other', ("
-assert_file_has_content_literal raw-summary.txt "{'ostree.summary.last-modified': <uint64"
+assert_file_has_content_literal raw-summary.txt "'ostree.summary.last-modified': <uint64"
 echo "ok view summary raw"


### PR DESCRIPTION
These are cherry-picks of the following two PRs from upstream OSTree, which improve gnome-software/flatpak/OSTree’s performance on high-latency network connections:
 * https://github.com/ostreedev/ostree/pull/2166
 * https://github.com/ostreedev/ostree/pull/2167

There were some minor cherry-pick conflicts, noted in the commit messages.

I would also have liked to cherry pick https://github.com/ostreedev/ostree/pull/2205, but there were too many conflicts and I would have essentially had to rewrite a significant chunk of it, which didn’t seem worth it for the impact the changes would have. We’ll get them when we rebase OSTree.

https://phabricator.endlessm.com/T30404