### PR TITLE
[Infrastructure] Allow skipping verification binding on pulls

### DIFF
--- a/bash/ostree
+++ b/bash/ostree
@@ -847,6 +847,7 @@ _ostree_pull_local() {
         --gpg-verify-summary
         --require-static-deltas
         --untrusted
+        --disable-verify-bindings
     "
 
     local options_with_args="
@@ -902,6 +903,7 @@ _ostree_pull() {
         --untrusted
         --bareuseronly-files
         --dry-run
+        --disable-verify-bindings
     "
 
     local options_with_args="

--- a/man/ostree-pull-local.xml
+++ b/man/ostree-pull-local.xml
@@ -90,6 +90,14 @@ Boston, MA 02111-1307, USA.
                     Do not trust source, verify checksums and don't hardlink into source.
                 </para></listitem>
             </varlistentry>
+
+            <varlistentry>
+                <term><option>--disable-verify-bindings</option></term>
+
+                <listitem><para>
+                    Disable verification of commit metadata bindings.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 

--- a/man/ostree-pull.xml
+++ b/man/ostree-pull.xml
@@ -137,6 +137,14 @@ Boston, MA 02111-1307, USA.
                     Specifies how many times each download should be retried upon error (default: 5)
                 </para></listitem>
             </varlistentry>
+
+            <varlistentry>
+                <term><option>--disable-verify-bindings</option></term>
+
+                <listitem><para>
+                    Disable verification of commit metadata bindings.
+                </para></listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 

--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -1809,17 +1809,19 @@ scan_commit_object (OtPullData                 *pull_data,
   if (!ostree_repo_load_commit (pull_data->repo, checksum, &commit, &commitstate, error))
     return FALSE;
 
-  if (!pull_data->disable_verify_bindings) {
-    /* If ref is non-NULL then the commit we fetched was requested through the
-     * branch, otherwise we requested a commit checksum without specifying a branch.
-     */
-    g_autofree char *remote_collection_id = NULL;
-    remote_collection_id = get_remote_repo_collection_id (pull_data);
-    if (!_ostree_repo_verify_bindings (remote_collection_id,
-                                       (ref != NULL) ? ref->ref_name : NULL,
-                                       commit, error))
-      return glnx_prefix_error (error, "Commit %s", checksum);
-  }
+  if (!pull_data->disable_verify_bindings)
+    {
+      /* If ref is non-NULL then the commit we fetched was requested through
+       * the branch, otherwise we requested a commit checksum without
+       * specifying a branch.
+       */
+      g_autofree char *remote_collection_id = NULL;
+      remote_collection_id = get_remote_repo_collection_id (pull_data);
+      if (!_ostree_repo_verify_bindings (remote_collection_id,
+                                         (ref != NULL) ? ref->ref_name : NULL,
+                                         commit, error))
+        return glnx_prefix_error (error, "Commit %s", checksum);
+    }
 
   if (pull_data->timestamp_check)
     {

--- a/src/ostree/ot-builtin-pull-local.c
+++ b/src/ostree/ot-builtin-pull-local.c
@@ -38,6 +38,7 @@ static gboolean opt_bareuseronly_files;
 static gboolean opt_require_static_deltas;
 static gboolean opt_gpg_verify;
 static gboolean opt_gpg_verify_summary;
+static gboolean opt_disable_verify_bindings;
 static int opt_depth = 0;
 
 /* ATTENTION:
@@ -53,6 +54,7 @@ static GOptionEntry options[] = {
   { "require-static-deltas", 0, 0, G_OPTION_ARG_NONE, &opt_require_static_deltas, "Require static deltas", NULL },
   { "gpg-verify", 0, 0, G_OPTION_ARG_NONE, &opt_gpg_verify, "GPG verify commits (must specify --remote)", NULL },
   { "gpg-verify-summary", 0, 0, G_OPTION_ARG_NONE, &opt_gpg_verify_summary, "GPG verify summary (must specify --remote)", NULL },
+  { "disable-verify-bindings", 0, 0, G_OPTION_ARG_NONE, &opt_disable_verify_bindings, "Do not verify commit bindings", NULL },
   { "depth", 0, 0, G_OPTION_ARG_INT, &opt_depth, "Traverse DEPTH parents (-1=infinite) (default: 0)", "DEPTH" },
   { NULL }
 };
@@ -175,6 +177,8 @@ ostree_builtin_pull_local (int argc, char **argv, OstreeCommandInvocation *invoc
     if (opt_gpg_verify_summary)
       g_variant_builder_add (&builder, "{s@v}", "gpg-verify-summary",
                              g_variant_new_variant (g_variant_new_boolean (TRUE)));
+    g_variant_builder_add (&builder, "{s@v}", "disable-verify-bindings",
+                           g_variant_new_variant (g_variant_new_boolean (opt_disable_verify_bindings)));
     g_variant_builder_add (&builder, "{s@v}", "depth",
                            g_variant_new_variant (g_variant_new_int32 (opt_depth)));
 

--- a/src/ostree/ot-builtin-pull.c
+++ b/src/ostree/ot-builtin-pull.c
@@ -37,6 +37,7 @@ static gboolean opt_require_static_deltas;
 static gboolean opt_untrusted;
 static gboolean opt_http_trusted;
 static gboolean opt_timestamp_check;
+static gboolean opt_disable_verify_bindings;
 static gboolean opt_bareuseronly_files;
 static char** opt_subpaths;
 static char** opt_http_headers;
@@ -72,6 +73,7 @@ static GOptionEntry options[] = {
    { "network-retries", 0, 0, G_OPTION_ARG_INT, &opt_network_retries, "Specifies how many times each download should be retried upon error (default: 5)", "N"},
    { "localcache-repo", 'L', 0, G_OPTION_ARG_FILENAME_ARRAY, &opt_localcache_repos, "Add REPO as local cache source for objects during this pull", "REPO" },
    { "timestamp-check", 'T', 0, G_OPTION_ARG_NONE, &opt_timestamp_check, "Require fetched commits to have newer timestamps", NULL },
+   { "disable-verify-bindings", 0, 0, G_OPTION_ARG_NONE, &opt_disable_verify_bindings, "Do not verify commit bindings", NULL },
    /* let's leave this hidden for now; we just need it for tests */
    { "append-user-agent", 0, G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_STRING, &opt_append_user_agent, "Append string to user agent", NULL },
    { NULL }
@@ -318,6 +320,8 @@ ostree_builtin_pull (int argc, char **argv, OstreeCommandInvocation *invocation,
     if (opt_localcache_repos)
       g_variant_builder_add (&builder, "{s@v}", "localcache-repos",
                              g_variant_new_variant (g_variant_new_strv ((const char*const*)opt_localcache_repos, -1)));
+    g_variant_builder_add (&builder, "{s@v}", "disable-verify-bindings",
+                           g_variant_new_variant (g_variant_new_boolean (opt_disable_verify_bindings)));
 
     if (opt_http_headers)
       {

--- a/tests/pull-test.sh
+++ b/tests/pull-test.sh
@@ -368,7 +368,7 @@ repo_init --no-gpg-verify
 ${CMD_PREFIX} ostree --repo=repo pull origin main@${prev_rev}
 ${CMD_PREFIX} ostree --repo=repo pull --dry-run --require-static-deltas origin ${delta_target} >dry-run-pull.txt
 # Compression can vary, so we support 400-699
-delta_dry_run_regexp='Delta update: 0/1 parts, 0 bytes/[456][0-9][0-9] bytes, 455 bytes total uncompressed'
+delta_dry_run_regexp='Delta update: 0/1 parts, 0[  ]bytes/[456][0-9][0-9][  ]bytes, 455[  ]bytes total uncompressed'
 assert_file_has_content dry-run-pull.txt "${delta_dry_run_regexp}"
 rev=$(${CMD_PREFIX} ostree --repo=repo rev-parse origin:main)
 assert_streq "${prev_rev}" "${rev}"

--- a/tests/pull-test2.sh
+++ b/tests/pull-test2.sh
@@ -55,7 +55,7 @@ ${CMD_PREFIX} ostree --repo=ostree-srv/repo static-delta generate ${remote_ref}
 ${CMD_PREFIX} ostree --repo=ostree-srv/repo summary -u
 ${CMD_PREFIX} ostree --repo=repo pull origin ${remote_ref}@${prev_rev}
 ${CMD_PREFIX} ostree --repo=repo pull --dry-run --require-static-deltas origin ${remote_ref} >dry-run-pull.txt
-assert_file_has_content dry-run-pull.txt 'Delta update: 0/1 parts, 0 bytes/[45][0-9].[0-9] kB, 1.[678] MB total uncompressed'
+assert_file_has_content dry-run-pull.txt 'Delta update: 0/1 parts, 0 bytes/[45][0-9].[0-9][  ]kB, 1.[678][  ]MB total uncompressed'
 ${CMD_PREFIX} ostree --repo=repo pull --require-static-deltas origin ${remote_ref}
 final_rev=$(${CMD_PREFIX} ostree --repo=repo rev-parse origin:${remote_ref})
 assert_streq "${rev}" "${final_rev}"

--- a/tests/test-pull-collections.sh
+++ b/tests/test-pull-collections.sh
@@ -105,7 +105,7 @@ do_pull() {
     local branch=$3
     shift 3
 
-    if ${CMD_PREFIX} ostree "--repo=${repo}" pull "${remote_repo}-remote" "${branch}"
+    if ${CMD_PREFIX} ostree "--repo=${repo}" pull "$@" "${remote_repo}-remote" "${branch}"
     then return 0
     else return 1
     fi
@@ -117,7 +117,7 @@ do_local_pull() {
     local branch=$3
     shift 3
 
-    if ${CMD_PREFIX} ostree "--repo=${repo}" pull-local "${remote_repo}" "${branch}"
+    if ${CMD_PREFIX} ostree "--repo=${repo}" pull-local "$@" "${remote_repo}" "${branch}"
     then return 0
     else return 1
     fi
@@ -209,19 +209,23 @@ if do_pull local collection-repo badcref1
 then
     assert_not_reached "pulling a commit without collection ID from a repo with collection ID should fail"
 fi
+do_pull local collection-repo badcref1 --disable-verify-bindings
 if do_pull local collection-repo badcref2
 then
     assert_not_reached "pulling a commit with a mismatched collection ID from a repo with collection ID should fail"
 fi
+do_pull local collection-repo badcref2 --disable-verify-bindings
 if do_pull local collection-repo badcref3
 then
     assert_not_reached "pulling a commit with empty collection ID from repo with collection ID should fail"
 fi
+do_pull local collection-repo badcref3 --disable-verify-bindings
 do_pull local collection-repo goodcref1
 if do_pull local collection-repo badcref4
 then
     assert_not_reached "pulling a commit that was not requested from repo with collection ID should fail"
 fi
+do_pull local collection-repo badcref4 --disable-verify-bindings
 
 echo "ok 5 pull refs from remote repos"
 
@@ -231,18 +235,22 @@ if do_local_pull local collection-local-repo badclref1
 then
     assert_not_reached "pulling a commit without collection ID from a repo with collection ID should fail"
 fi
+do_local_pull local collection-local-repo badclref1 --disable-verify-bindings
 if do_local_pull local collection-local-repo badclref2
 then
     assert_not_reached "pulling a commit with a mismatched collection ID from a repo with collection ID should fail"
 fi
+do_local_pull local collection-local-repo badclref2 --disable-verify-bindings
 if do_local_pull local collection-local-repo badclref3
 then
     assert_not_reached "pulling a commit with empty collection ID from repo with collection ID should fail"
 fi
+do_local_pull local collection-local-repo badclref3 --disable-verify-bindings
 do_local_pull local collection-local-repo goodclref1
 if do_local_pull local collection-local-repo badclref4
 then
     assert_not_reached "pulling a commit that was not requested from repo with collection ID should fail"
 fi
+do_local_pull local collection-local-repo badclref4 --disable-verify-bindings
 
 echo "ok 6 pull refs from local repos"


### PR DESCRIPTION
2 backports from upstream that add an option to skip verification of commit bindings on pulls. This is needed for some work to merge together our current per arch `eos-$arch` repos into one `eos` repo. Our OS repos have many older released commits that lack collection and ref bindings but now live in a repository that has a collection ID. I also found at least one commit that had the wrong ref bindings from the early days when we were getting the bindings in place.

Upstream PRs were ostreedev/ostree#2253 and ostreedev/ostree#2254.

https://phabricator.endlessm.com/T20138