### PR TITLE
Repo locking API packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,7 @@ Build-Depends:
  libcap-dev,
  libfuse-dev,
  libgirepository1.0-dev,
- libglib2.0-dev (>= 2.40.0),
+ libglib2.0-dev (>= 2.44.0),
  libgpgme-dev,
  liblzma-dev,
  libmount-dev (>= 2.23),

--- a/debian/libostree-1-1.symbols
+++ b/debian/libostree-1-1.symbols
@@ -36,6 +36,7 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  LIBOSTREE_2020.4@LIBOSTREE_2020.4 2020.4
  LIBOSTREE_2020.7@LIBOSTREE_2020.7 2020.7
  LIBOSTREE_2020.8@LIBOSTREE_2020.8 2020.8
+ LIBOSTREE_2021.3@LIBOSTREE_2021.3 2020.8
  ostree_async_progress_copy_state@LIBOSTREE_2019.6 2019.6
  ostree_async_progress_finish@LIBOSTREE_2016.3 2016.4
  ostree_async_progress_get@LIBOSTREE_2017.6 2017.6
@@ -202,6 +203,8 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_repo_abort_transaction@LIBOSTREE_2016.3 2016.4
  ostree_repo_add_gpg_signature_summary@LIBOSTREE_2016.3 2016.4
  ostree_repo_append_gpg_signature@LIBOSTREE_2016.3 2016.4
+ ostree_repo_auto_lock_cleanup@LIBOSTREE_2021.3 2020.8
+ ostree_repo_auto_lock_push@LIBOSTREE_2021.3 2020.8
  ostree_repo_checkout_at@LIBOSTREE_2016.8 2016.8
  ostree_repo_checkout_at_options_set_devino@LIBOSTREE_2017.13 2017.13
  ostree_repo_checkout_gc@LIBOSTREE_2016.3 2016.4
@@ -306,6 +309,8 @@ libostree-1.so.1 libostree-1-1 #MINVER#
  ostree_repo_load_object_stream@LIBOSTREE_2016.3 2016.4
  ostree_repo_load_variant@LIBOSTREE_2016.3 2016.4
  ostree_repo_load_variant_if_exists@LIBOSTREE_2016.3 2016.4
+ ostree_repo_lock_pop@LIBOSTREE_2021.3 2020.8
+ ostree_repo_lock_push@LIBOSTREE_2021.3 2020.8
  ostree_repo_mark_commit_partial@LIBOSTREE_2017.15 2017.15
  ostree_repo_mark_commit_partial_reason@LIBOSTREE_2019.4 2019.4
  ostree_repo_mode_from_string@LIBOSTREE_2016.3 2016.4


### PR DESCRIPTION
Packaging changes to support the repo locking API backport in #184. Technically the package version used in the symbols file should be `2020.8+dev<something>` but we don't know what `<something>` is until the merge has been made and jenkins generates the new version. A bare `2020.8` version is good enough for our usage.

https://phabricator.endlessm.com/T31868