### PR TITLE
lib/repo: Add commit version metadata to summary metadata

### DIFF
--- a/man/ostree-summary.xml
+++ b/man/ostree-summary.xml
@@ -183,6 +183,7 @@ License along with this library. If not, see <https://www.gnu.org/licenses/>.
     Latest Commit (4.2 MB):
       9828ab80f357459b4ab50f0629beab2ae3b67318fc3d161d10a89fae353afa90
     Timestamp (ostree.commit.timestamp): 2017-11-21T01:41:10-08
+    Version (ostree.commit.version): 1.2.3
 
 Last-Modified (ostree.summary.last-modified): 2018-01-12T22:06:38-08
 </programlisting>

--- a/src/libostree/ostree-core.h
+++ b/src/libostree/ostree-core.h
@@ -164,6 +164,8 @@ typedef enum {
  * The currently defined keys for the `a{sv}` of additional metadata for each commit are:
  *  - key: `ostree.commit.timestamp`, value: `t`, timestamp (seconds since the
  *    Unix epoch in UTC, big-endian) when the commit was committed
+ *  - key: `ostree.commit.version`, value: `s`, the `version` value from the
+ *    commit's metadata if it was defined. Since: 2022.2
  */
 #define OSTREE_SUMMARY_GVARIANT_STRING "(a(s(taya{sv}))a{sv})"
 #define OSTREE_SUMMARY_GVARIANT_FORMAT G_VARIANT_TYPE (OSTREE_SUMMARY_GVARIANT_STRING)

--- a/src/libostree/ostree-repo-private.h
+++ b/src/libostree/ostree-repo-private.h
@@ -63,6 +63,7 @@ G_BEGIN_DECLS
 /* Well-known keys for the additional metadata field in a commit in a ref entry
  * in a summary file. */
 #define OSTREE_COMMIT_TIMESTAMP "ostree.commit.timestamp"
+#define OSTREE_COMMIT_VERSION "ostree.commit.version"
 
 typedef enum {
   OSTREE_REPO_TEST_ERROR_PRE_COMMIT = (1 << 0),

--- a/src/libostree/ostree-repo.c
+++ b/src/libostree/ostree-repo.c
@@ -6064,16 +6064,21 @@ summary_add_ref_entry (OstreeRepo       *self,
   g_autoptr(GVariant) commit_obj = NULL;
   if (!ostree_repo_load_variant (self, OSTREE_OBJECT_TYPE_COMMIT, checksum, &commit_obj, error))
     return FALSE;
+  g_autoptr(GVariant) orig_metadata = g_variant_get_child_value (commit_obj, 0);
 
   g_variant_dict_init (&commit_metadata_builder, NULL);
 
-  /* Forward the commit’s timestamp if it’s valid. */
+  /* Forward the commit’s timestamp and version if they're valid. */
   guint64 commit_timestamp = ostree_commit_get_timestamp (commit_obj);
   g_autoptr(GDateTime) dt = g_date_time_new_from_unix_utc (commit_timestamp);
 
   if (dt != NULL)
     g_variant_dict_insert_value (&commit_metadata_builder, OSTREE_COMMIT_TIMESTAMP,
                                  g_variant_new_uint64 (GUINT64_TO_BE (commit_timestamp)));
+
+  const char *version = NULL;
+  if (g_variant_lookup (orig_metadata, OSTREE_COMMIT_META_KEY_VERSION, "&s", &version))
+    g_variant_dict_insert (&commit_metadata_builder, OSTREE_COMMIT_VERSION, "s", version);
 
   g_variant_builder_add_value (refs_builder,
                                g_variant_new ("(s(t@ay@a{sv}))", ref,

--- a/src/ostree/ot-dump.c
+++ b/src/ostree/ot-dump.c
@@ -249,6 +249,11 @@ dump_summary_ref (const char   *collection_id,
           pretty_key = "Timestamp";
           value_str = uint64_secs_to_iso8601 (GUINT64_FROM_BE (g_variant_get_uint64 (value)));
         }
+      else if (g_strcmp0 (key, OSTREE_COMMIT_VERSION) == 0)
+        {
+          pretty_key = "Version";
+          value_str = g_strdup (g_variant_get_string (value, NULL));
+        }
       else
         {
           value_str = g_variant_print (value, FALSE);

--- a/tests/test-summary-view.sh
+++ b/tests/test-summary-view.sh
@@ -56,6 +56,7 @@ assert_file_has_content_literal summary.txt "* main"
 assert_file_has_content_literal summary.txt "* other"
 assert_file_has_content_literal summary.txt "ostree.summary.last-modified"
 assert_file_has_content_literal summary.txt "Timestamp (ostree.commit.timestamp): "
+assert_file_has_content_literal summary.txt "Version (ostree.commit.version): 3.2"
 echo "ok view summary"
 
 # Check the summary can be viewed raw too.


### PR DESCRIPTION
The commit metadata `version` key is well established but getting it for
a remote commit is cumbersome since the commit object needs to be
fetched and loaded. Including it in the summary additional metadata
allows a much more convenient view of what each of the remote refs
represents.

(cherry picked from commit 6fbf759279ca9908e0c7ceb2a3af75b1180fa8a1)

https://phabricator.endlessm.com/T33099

This is only really needed on the server as in #188, but this does include the cosmetic change that the CLI summary view will show `Version` instead of `ostree.commit.version`. The other benefit is to not have server only changes unless they're really needed.