### PR TITLE
Recent ostree backport fixes for eos3.9

### DIFF
--- a/src/libostree/ostree-repo-pull.c
+++ b/src/libostree/ostree-repo-pull.c
@@ -2421,6 +2421,9 @@ process_one_static_delta (OtPullData                 *pull_data,
                                                ref, cancellable, error))
             return FALSE;
 
+          if (!ostree_repo_mark_commit_partial (pull_data->repo, to_revision, TRUE, error))
+            return FALSE;
+
           if (detached_data && !ostree_repo_write_commit_detached_metadata (pull_data->repo,
                                                                             to_revision,
                                                                             detached_data,

--- a/src/libotutil/ot-variant-builder.c
+++ b/src/libotutil/ot-variant-builder.c
@@ -832,7 +832,7 @@ static void
 ot_variant_builder_info_free (OtVariantBuilderInfo *info)
 {
   if (info->parent)
-    ot_variant_builder_info_free (info);
+    ot_variant_builder_info_free (info->parent);
 
   g_variant_type_free (info->type);
   g_array_unref (info->child_ends);


### PR DESCRIPTION
A couple fixes from upstream that coincide with Debian's [proposed bullseye update](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1006905). The delta commit partial fix is important. The infinite recursion one I haven't seen in practice but the code was clearly wrong before and crash if it was reached. Since this is for 3.9, we may only want critical fixes, so I'm fine if the infinite recursion one is dropped.

https://phabricator.endlessm.com/T33209