### PR TITLE
Revert "grub2: Disable use of grub-mkconfig on Endless"

### DIFF
--- a/src/libostree/ostree-bootloader-grub2.c
+++ b/src/libostree/ostree-bootloader-grub2.c
@@ -76,16 +76,6 @@ _ostree_bootloader_grub2_query (OstreeBootloader *bootloader,
 {
   OstreeBootloaderGrub2 *self = OSTREE_BOOTLOADER_GRUB2 (bootloader);
 
-  /* FIXME: Endless specific patch: don't let libostree find our
-   * /boot/grub/grub.cfg because we manage that separately and disable
-   * grub-mkconfig. See:
-   * - https://phabricator.endlessm.com/T19614
-   * - https://phabricator.endlessm.com/T18848 */
-  {
-    *out_is_active = FALSE;
-    return TRUE;
-  }
-
   /* Look for the BIOS path first */
   if (g_file_query_exists (self->config_path_bios_1, NULL) ||
       g_file_query_exists (self->config_path_bios_2, NULL))


### PR DESCRIPTION
This reverts commit 344474a916afda24a84932faf95a20578631d36c. All systems have been converted to declare the desired bootloader in the repository configuration `sysroot.bootloader` option. On grub systems this is set to `none` so that only the boot loader spec entries are updated. This and the reverted commit should be dropped during the next upstream rebase.

https://phabricator.endlessm.com/T34161