### PR TITLE
Build with libcurl http backend instead of libsoup2.4

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,7 @@ Build-Depends:
  libavahi-client-dev (>= 0.6.31),
  libavahi-glib-dev (>= 0.6.31),
  libcap-dev,
+ libcurl4-gnutls-dev | libcurl-dev,
  libfuse3-dev,
  libgirepository1.0-dev,
  libglib2.0-dev (>= 2.44.0),

--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,7 @@ override_dh_autoreconf:
 configure_options = \
 	--enable-installed-tests \
 	--with-avahi \
+	--with-curl \
 	--with-dracut \
 	--with-grub2 \
 	--with-grub2-mkconfig-path=/usr/sbin/grub-mkconfig \


### PR DESCRIPTION
This avoids library conflicts during the transition to GNOME 43, in which core apps and libraries have switched to libsoup3, which conflicts with libsoup2.4.

We still build-depend on libsoup2.4, because it's used in the test suite and installed-tests.

Closes: #1016589
(cherry picked from commit 53261afd32e3772e9ee1484432f6bbb16c38500f)

https://phabricator.endlessm.com/T35040